### PR TITLE
Add migration plan and documentation baseline for Astro migration

### DIFF
--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: migrate
+description: Run one phase of the fastpages-to-Astro migration described in docs/migration-plan.md.
+argument-hint: "[phase-number]"
+arguments: [phase]
+disable-model-invocation: true
+---
+
+Run exactly one phase of the Astro migration.
+
+## 1. Orient
+
+Read, in this order:
+
+1. `docs/migration-plan.md` — invariants, pre-made decisions, the "Do not" list,
+   the phases, and the handoff log at the bottom
+2. `AGENTS.md` — conventions
+3. `docs/code-map.md` — where things belong
+
+Work out which phase is yours:
+
+- If `$phase` is set, that is your phase.
+- Otherwise read the `**Status:**` line at the top of the plan and take the
+  phase named after `Next:`.
+- If that line is missing, ambiguous, or disagrees with what is actually on
+  disk, **stop and ask.** Do not guess.
+
+Say which phase you are starting and what its gate is, then begin.
+
+## 2. Work
+
+Do that phase and nothing else. If you notice a problem belonging to another
+phase, record it in the handoff log — do not fix it.
+
+The plan's pre-made decisions are settled. If one turns out to be impossible,
+**stop and ask** rather than substituting an alternative.
+
+## 3. Finish
+
+Before opening a pull request:
+
+1. Confirm your phase's gate passes. If it does not, stop and report why.
+   Do not open the PR.
+2. Update the `**Status:**` line to `Phase N complete. Next: Phase N+1.`
+3. Append your entry to the handoff log at the bottom of the plan.
+   **Ten lines maximum.** Only: what differed from the plan, what the next agent
+   needs to know, and anything left broken.
+4. If a step in the plan was wrong, **edit that step** so it is right. Do not
+   annotate it with what you did instead.
+5. If a real decision changed, add one short entry to `docs/decisions.md`.
+
+Then open a pull request against `master`. **Do not merge it.** The PR
+description is for the repository owner, not the next agent — say what you did,
+what surprised you, and what wants a human eye.
+
+## Never
+
+- Restructure or expand docs outside your phase. The line budgets in the plan
+  are limits, not targets.
+- Write handoff notes about phases you did not run.
+- Merge anything, or push to `master`.
+- Re-execute notebooks, change published URLs, or delete the Jekyll tree before
+  Phase 7.
+
+---
+
+This skill is temporary. Delete it when the migration lands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+How to work in this repo. Keep it this short.
+
+**Status:** migrating from fastpages/Jekyll to Astro. The Jekyll tree (`_*`
+directories, `Gemfile`) still publishes the live site; the Astro tree (`src/`,
+`astro.config.mjs`) is being built alongside it. Phase order and gates:
+[`docs/migration-plan.md`](docs/migration-plan.md). The Jekyll tree is deleted
+last, and only with the owner's approval.
+
+## Commands
+
+| Command | What |
+|---|---|
+| `npm run dev` | Local preview at `localhost:4321`, hot reload |
+| `npm run build` | Static build into `dist/` |
+| `npx astro check` | Types and content schema. Run before every commit |
+| `npm test` | URL parity, smoke tests, internal link check |
+
+## Layout
+
+Where things live: [`docs/code-map.md`](docs/code-map.md).
+Why they're that way: [`docs/decisions.md`](docs/decisions.md).
+
+## Conventions
+
+- Posts are Markdown in `src/content/posts/<slug>/`, images alongside them.
+  Use `.mdx` only when a post genuinely needs a component.
+- Front matter is validated by `src/content.config.ts`. Add a field there before
+  using it anywhere.
+- Plain CSS with custom properties, in `src/styles/`. No CSS framework.
+- Components render at build time by default. A `client:*` directive ships
+  JavaScript to visitors — reach for it deliberately, not by habit.
+
+## Invariants
+
+1. **Published URLs never change.** The list is `tests/expected-urls.json`,
+   enforced by the URL parity test. Inbound links depend on these.
+2. **Notebooks are never executed.** `notebooks/*.ipynb` carry their saved
+   outputs. The conversion script reads them; it does not run them. No ML
+   dependencies belong in this repo.
+3. **The five 2022 posts are archives.** Add TL;DRs, tags, and formatting fixes.
+   Do not rewrite the prose or redo the analysis.
+4. **Static only.** No SSR adapter, no server endpoints — GitHub Pages serves
+   files and nothing else. The contact form uses Formspree for this reason.
+
+## Ask first
+
+Before adding a dependency, a client-side island, a new top-level directory, or
+anything outside the current phase of the migration plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ How to work in this repo. Keep it this short.
 directories, `Gemfile`) still publishes the live site; the Astro tree (`src/`,
 `astro.config.mjs`) is being built alongside it. Phase order and gates:
 [`docs/migration-plan.md`](docs/migration-plan.md). The Jekyll tree is deleted
-last, and only with the owner's approval.
+last, and only with the owner's approval. Run a single phase with `/migrate`.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
-[//]: # (This template replaces README.md when someone creates a new repo with the fastpages template.)
+# david-recio.com
 
-![](https://github.com/recmit/my-blog/workflows/CI/badge.svg) 
-![](https://github.com/recmit/my-blog/workflows/GH-Pages%20Status/badge.svg) 
-[![](https://img.shields.io/static/v1?label=fastai&message=fastpages&color=57aeac&labelColor=black&style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAjCAYAAABhCKGoAAAGMklEQVR42q1Xa0xTVxyfKExlui9blszoB12yDzPGzJhtyT5s+zBxUxELBQSHm2ZzU5epBF/LclXae29pCxR5VEGgLQUuIOKDuClhm8oUK7S9ve19tLTl/fA5p9MNc/Y/hRYEzGLxJL/87zk9Ob/zf5++NGHMALzYgdDYmWh0Qly3Lybtwi6lXdpN2cWN5A0+hrQKe5R2PoN2uD+OKcn/UF5ZsVduMmyXVRi+jzebdmI5/juhwrgj3mTI2GA0vvsUIcMwM7GkOD42t7Mf6bqHkFry2yk7X5PXcxMVDN5DGtFf9NkJfe6W5iaUyFShjfV1KPlk7VPAa0k11WjzL+eRvMJ4IKQO0dw8SydJL+Op0u5cn+3tQTn+fqTivTbQpiavF0iG7iGt6NevKjpKpTbUo3hj+QO47XB8hfHfIGAelA+T6mqQzFi+e0oTKm3iexQnXaU56ZrK5SlVsq70LMF7TuX0XNTyvi1rThzLST3TgOCgxwD0DPwDGoE07QkcSl/m5ynbHWmZVm6b0sp9o2DZN8aTZtqk9w9b2G2HLbbvsjlx+fry0vwU0OS5SH68Ylmilny3c3x9SOvpRuQN7hO8vqulZQ6WJMuXFAzcRfkDd5BG8B1bpc+nU0+fQtgkYLIngOEJwGt/J9UxCIJg1whJ05Ul4IMejbsLqUUfOjJKQnCDr4ySHMeO1/UMIa3UmR9TUpj7ZdMFJK8yo6RaZjLAF/JqM/rifCO+yP4AycGmlgUaT9cZ0OYP2um5prjBLhtvLhy68Fs7RFqbRvSlf15ybGdyLcPJmcpfIcIuT4nqqt+Sa2vaZaby1FB+JGi1c9INhuiv9fpIysItIh3CVgVAzXfEE1evzse/bwr8bolcAXs+zcqKXksQc5+FD2D/svT06I8IYtaUeZLZzsVm+3oRDmON1Ok/2NKyIJSs0xnj84RknXG6zgGEE1It+rsPtrYuDOxBKAJLrO1qnW7+OpqeNxF4HWv6v4Rql3uFRvL/DATnc/29x4lmy2t4fXVjY+ASGwylm8DBvkSm2gpgx1Bpg4hyyysqVoUuFRw0z8+jXe40yiFsp1lpC9navlJpE9JIh7RVwfJywmKZO4Hkh02NZ1FilfkJLi1B4GhLPduAZGazHO9LGDX/WAj7+npzwUQqvuOBoo1Va91dj3Tdgyinc0Dae+HyIrxvc2npbCxlxrJvcW3CeSKDMhKCoexRYnUlSqg0xU0iIS5dXwzm6c/x9iKKEx8q2lkV5RARJCcm9We2sgsZhGZmgMYjJOU7UhpOIqhRwwlmEwrBZHgCBRKkKX4ySVvbmzQnXoSDHWCyS6SV20Ha+VaSFTiSE8/ttVheDe4NarLxVB1kdE0fYAgjGaOWGYD1vxKrqmInkSBchRkmiuC4KILhonAo4+9gWVHYnElQMEsAxbRDSHtp7dq5CRWly2VlZe/EFRcvDcBQvBTPZeXly1JMpvlThzBBRASBoDsSBIpgOBQV6C+sUJzffwflQX8BTevCTZMZeoslUo9QJJZYTZDw3RuIKtIhlhXdfhDoJ7TTXY/XdBBpgUshwFMSRYTVwim7FJvt6aFyOnoVKqc7MZQDzzNwsmnd3UegCudl8R2qzHZ7bJbQoYGyn692+zMULCfXenoOacTOTBUnJYRFsq+5+a3sjp5BXM6hEz7ObHNoVEIHyocekiX6WIiykwWDd1HhzT8RzY2YqxnK0HNQBJtW500ddiwrDgdIeCABZ4MPnKQdk9xDhUP3wfHSqbBI9v/e9jo0Iy30cCOgAMyVgMMVCMwql/cQxfKp2R1dWWrRm0PzUkrIXC9ykDY+hnJ5DqkE709guriwSRgGzWTQCPABWJZ6vbNHQlgo099+CCEMPnF6xnwynYETEWd8ls0WPUpSWnTrfuAhAWacPslUiQRNLBGXFSA7TrL8V3gNhesTnLFY0jb+bYWVp0i7SClY184jVtcayi7so2yuA0r4npbjsV8CJHZhPQ7no323cJ5w8FqpLwR/YJNRnHs0hNGs6ZFw/Lpsb+9oj/dZSbuL0XUNojx4d9Gch5mOT0ImINsdKyHzT9Muz1lcXhRWbo9a8J3B72H8Lg6+bKb1hyWMPeERBXMGRxEBCM7Ddfh/1jDuWhb5+QkAAAAASUVORK5CYII=)](https://github.com/fastai/fastpages)
+Personal blog. Posts on statistics and machine learning, written while moving
+from pure mathematics research into software engineering.
 
-https://david-recio.com
+Live at **<https://david-recio.com>**.
 
-# My Blog
+## Status
 
+Migrating from [fastpages](https://github.com/fastai/fastpages), deprecated
+since 2022, to [Astro](https://astro.build). The Jekyll build still publishes
+the site; the Astro replacement is being built alongside it. Plan and phase
+order: [`docs/migration-plan.md`](docs/migration-plan.md).
 
-_powered by [fastpages](https://github.com/fastai/fastpages)_
+## Running it locally
 
+```sh
+npm install
+npm run dev      # http://localhost:4321
+```
 
-## What To Do Next?
+## Adding a post
 
-Great!  You have setup your repo.  Now its time to start writing content.  Some helpful links:
+Create `src/content/posts/<slug>/index.md` with front matter matching
+`src/content.config.ts`, and put its images in the same directory.
 
-- [Writing Blogs With Jupyter](https://github.com/fastai/fastpages#writing-blog-posts-with-jupyter)
+The five 2022 posts came from Jupyter notebooks, kept in `notebooks/` for
+provenance. They are archives and are not rebuilt from source.
 
-- [Writing Blogs With Markdown](https://github.com/fastai/fastpages#writing-blog-posts-with-markdown)
+## Docs
 
-- [Writing Blog Posts With Word](https://github.com/fastai/fastpages#writing-blog-posts-with-microsoft-word)
+- [`AGENTS.md`](AGENTS.md) — working conventions and invariants
+- [`docs/code-map.md`](docs/code-map.md) — where things live
+- [`docs/decisions.md`](docs/decisions.md) — why they're that way
 
-- [(Optional) Preview Your Blog Locally](_fastpages_docs/DEVELOPMENT.md)
+## License
 
-Note: you may want to remove example blog posts from the `_posts`,  `_notebooks` or `_word` folders (but leave them empty, don't delete these folders) if you don't want these blog posts to appear on your site.
-
-Please use the [nbdev & blogging channel](https://forums.fast.ai/c/fastai-users/nbdev/48) in the fastai forums for any questions or feature requests.
+[Apache 2.0](LICENSE)

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -1,0 +1,48 @@
+# Code map
+
+Where things live and why. This describes the target structure — the Astro tree
+arrives with the migration ([`migration-plan.md`](migration-plan.md)).
+
+## Content
+
+| Path | What |
+|---|---|
+| `notebooks/*.ipynb` | Source of truth for the five 2022 posts. Kept for provenance; read by the conversion script, never executed |
+| `src/content/posts/<slug>/` | One directory per post: `index.md` and its images |
+| `src/content.config.ts` | Front matter schema. A typo in a post's front matter fails the build here, loudly, instead of rendering blank |
+
+## Site
+
+| Path | What |
+|---|---|
+| `src/pages/` | One file per route. The post route generates the dated `.html` URLs |
+| `src/layouts/` | Page shells — `<head>`, nav, footer |
+| `src/components/` | Reusable pieces. Build-time unless marked `client:*` |
+| `src/styles/` | Plain CSS |
+| `public/` | Copied verbatim to the site root: `CNAME`, `robots.txt` |
+
+## Build and checks
+
+| Path | What |
+|---|---|
+| `astro.config.mjs` | Integrations, Markdown pipeline, URL format |
+| `scripts/convert-notebooks.sh` | One-time `.ipynb` → Markdown. **Not run in CI.** It ran once; its output is committed |
+| `tests/expected-urls.json` | The published URL surface, taken from the live deployment |
+| `tests/` | URL parity, Playwright smoke tests, internal link check |
+| `.github/workflows/deploy.yml` | Build → GitHub Pages |
+
+## Still present, due for deletion
+
+The Jekyll site fastpages built. Removed in the final migration phase, not
+before: `_config.yml`, `Gemfile*`, `_layouts/`, `_includes/`, `_sass/`,
+`_plugins/`, `_posts/`, `_pages/`, `_action_files/`, `_fastpages_docs/`,
+`_word/`, `assets/`, `images/`, `Makefile`, `settings.ini`,
+`docker-compose.yml`, `index.html`, `.devcontainer.json`.
+
+Note that `_posts/*.md` is generated output, not authored content — the
+notebooks are the originals.
+
+## Not in this repo
+
+DNS for `david-recio.com`, the Formspree endpoint, and the Google Analytics
+property are configured outside it. Changing them is not a code change.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -30,6 +30,7 @@ arrives with the migration ([`migration-plan.md`](migration-plan.md)).
 | `tests/expected-urls.json` | The published URL surface, taken from the live deployment |
 | `tests/` | URL parity, Playwright smoke tests, internal link check |
 | `.github/workflows/deploy.yml` | Build → GitHub Pages |
+| `.claude/skills/migrate/` | The `/migrate` command. Temporary — delete once the migration lands |
 
 ## Still present, due for deletion
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,40 @@
+# Decisions
+
+Why the repo is the way it is. One entry each: what, why, and what it rules out.
+
+## Astro, replacing fastpages — 2026-07
+
+fastpages was deprecated in 2022, and the build ran inside an unmaintained
+Docker image on Ruby 2.7-era gems; the site was on track to become unbuildable.
+
+Astro was chosen over Quarto (notebook-first, and this blog is moving away from
+notebooks), Hugo (no component model, so interactive pages mean hand-rolling),
+and Next.js (application-framework overhead on a five-post content site). Astro
+keeps interactive elements and a future backend available without charging for
+them up front.
+
+Rules out: little. Content stays portable Markdown, so a later move is cheap.
+
+## Notebooks frozen, out of the build
+
+The five 2022 posts were converted to Markdown once and committed. The
+notebooks were not re-executed — fastpages never did either, so the saved
+outputs have always been what shipped. This keeps Python and a 2022 ML
+dependency tree out of the build permanently.
+
+Costs: republishing a notebook means re-running the conversion script by hand.
+Acceptable, because these posts are archives.
+
+## GitHub Pages, for now
+
+Static hosting is sufficient and the domain already points there. Astro can move
+to a host with server support later by adding an adapter, so this is not a
+one-way door.
+
+Rules out: a backend. The contact form goes through Formspree as a result.
+
+## URLs frozen
+
+The published URL surface predates the current shape of this repo and is linked
+from job applications. It is pinned in `tests/expected-urls.json` and enforced
+by a test, rather than left to convention and good intentions.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -100,10 +100,14 @@ reviews and merges before the next begins.
 | Agent | Phases |
 |---|---|
 | A | 0–1 — baseline, parity test, scaffold |
-| B | 2 — notebook conversion, isolated and context-heavy |
+| B | 2 — notebook conversion. Isolated: the notebooks are 1.8 MB, ~95% of it stored outputs and base64 |
 | C | 3–4 — routes, layouts, feature parity |
-| D | 5–6 — improvements, tests, docs |
-| E | 7 — cutover, only once approved |
+| D | 5 — improvements. Reads all five posts to draft TL;DRs, so it gets its own agent |
+| E | 6 — tests and docs |
+| F | 7 — cutover, only once approved |
+
+Agent D should work post by post — draft, commit, move on — rather than
+reading all five before writing anything.
 
 Do not split a phase across agents. In particular, do not convert the five
 notebooks with five agents: the conversion script is written once and run five
@@ -208,7 +212,23 @@ pass — if it disagrees with your routes, your routes are wrong.
 
 - **Home page**: short intro + post list, replacing the current bare `# Posts`.
 - **TL;DR block** on each archived post: 3–5 bullets in the `tldr` front matter
-  field, rendered above the content. This is the "summarize" the user asked for.
+  field, rendered above the content. Draft these; the owner reviews and edits.
+  Three rules, because this is the only *authored* content in the migration and
+  it carries the owner's name:
+
+  - **Anchor on the post's existing `description` field.** The owner wrote those
+    in 2022 and they are accurate. Expand them into bullets — do not invent a
+    fresh framing or re-characterise the work.
+  - **Say what the post concluded**, not only what it did. The descriptions
+    already cover the method; the findings sit at the bottom of the notebook and
+    are the reason a reader keeps going.
+  - **Flag every bullet you are less than certain about** in the PR description.
+    A fluent, confident, wrong summary of someone else's statistics is the worst
+    output this migration can produce. Uncertainty is cheap to check; a wrong
+    claim published under the owner's name is not.
+
+  Put all five drafts in the PR description so they can be read together without
+  opening five files.
 - **Archive note** on each 2022 post: one line, e.g. *"Written in 2022, when I
   was moving from mathematics into industry. Left as it was."*
 - **Reading time** (currently commented out at `_layouts/post.html:39`).

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,279 @@
+# Migration plan: fastpages/Jekyll → Astro
+
+**Status:** not started
+**Branch:** `claude/portfolio-framework-recommendations-qnclw1`
+**Audience:** the implementer (human or agent).
+
+This file is a *work order*, not permanent documentation. It is prescriptive on
+purpose. Delete it once the migration lands. The docs it tells you to write
+(`AGENTS.md`, `docs/code-map.md`) are the opposite: short and permanent.
+
+---
+
+## Why
+
+The site is built by [fastpages](https://github.com/fastai/fastpages), deprecated
+since 2022. The build runs inside `docker://fastai/fastpages-jekyll@sha256:6db4173…`,
+an unmaintained image, on Ruby 2.7-era gems. If that image disappears, the site
+cannot be rebuilt. Astro replaces it: content stays portable, interactive pages
+become possible, and nothing depends on an abandoned toolchain.
+
+## Invariants — breaking any of these fails the migration
+
+1. **Every published URL keeps working.** Exact list in [Appendix A](#appendix-a).
+2. **`david-recio.com` stays live on GitHub Pages.** No DNS changes, no host change.
+3. **The five 2022 posts keep their content.** Do not rewrite, reword, re-order,
+   or "improve" the prose or the analysis. Additive changes only (see Phase 5).
+4. **Notebooks are never re-executed.** Outputs stored in the `.ipynb` files are
+   the source. No 2022 Python environment is needed and none should be built.
+5. **`master` is not touched** until the user explicitly approves the cutover.
+
+## Pre-made decisions — do not relitigate these
+
+| Decision | Choice |
+|---|---|
+| Framework | Astro 6, `output: 'static'` |
+| Host | GitHub Pages (unchanged) |
+| Notebook handling | Convert once to Markdown, commit the result, freeze |
+| Post format | `.md` (use `.mdx` only if a post needs a component) |
+| Islands | None yet. No React/Svelte/Vue until there's a reason |
+| Styling | Hand-written CSS + a few custom properties. No Tailwind, no Bootstrap |
+| Search | Pagefind (replaces lunr) |
+| Math | Rendered at build time (`remark-math` + `rehype-katex`), CSS only |
+| Analytics | Keep GA4 `G-J4ZRL7L1T1` |
+| Contact form | Keep Formspree. No backend |
+| Package manager | npm, lockfile committed |
+
+If something in this table turns out to be wrong or impossible, **stop and ask** —
+do not silently substitute an alternative.
+
+## Do not
+
+- Do not re-execute notebooks or install pandas/torch/transformers.
+- Do not change any URL in Appendix A.
+- Do not delete Jekyll files before Phase 7.
+- Do not open a pull request unless the user asks.
+- Do not add an SSR adapter, server endpoints, or Cloudflare config. Static only.
+- Do not redesign wholesale. Improvements in Phase 5 are the agreed scope.
+- Do not write docs longer than the budgets in Phase 6.
+
+---
+
+## Target structure
+
+```
+CLAUDE.md               → one line, points at AGENTS.md
+AGENTS.md               → how to work in this repo
+README.md               → what this is, how to run it
+docs/
+  code-map.md           → where things live and why
+  decisions.md          → short log of choices and their reasons
+notebooks/              → *.ipynb, source of truth, renamed from _notebooks/
+scripts/
+  convert-notebooks.sh  → one-time conversion, not run in CI
+src/
+  content/posts/<slug>/index.md + images
+  layouts/  components/  pages/  styles/
+public/                 → CNAME, robots.txt, static images
+tests/                  → urls.test.ts, smoke.spec.ts
+astro.config.mjs  package.json  .nvmrc
+.github/workflows/deploy.yml
+```
+
+---
+
+## Phases
+
+Each phase ends with a **gate**. Do not start the next phase until the gate
+passes. Commit at every gate.
+
+### Phase 0 — Baseline
+
+- Fetch `origin/gh-pages` (the currently deployed output) into a scratch dir.
+  It is the ground truth for both URLs and rendered appearance.
+- Save the URL list from Appendix A as `tests/expected-urls.json`.
+- Save a copy of one rendered post (e.g. `2022/03/19/grades-analysis.html`) for
+  visual comparison later.
+
+**Gate:** `tests/expected-urls.json` exists and contains 13 paths.
+
+### Phase 1 — Scaffold Astro alongside Jekyll
+
+Astro and Jekyll can coexist: Astro owns `src/`, `public/`, `astro.config.mjs`,
+`package.json`; Jekyll owns the `_*` directories. They do not collide.
+
+- `npm create astro@latest` — minimal template, TypeScript strict.
+- Add `src/`, `public/`, `node_modules`, `dist`, `package.json`, `package-lock.json`,
+  `tests` to `exclude:` in `_config.yml` so the Jekyll build ignores them.
+- Pin Node in `.nvmrc` and use the same version in CI.
+- Define the content collection schema in `src/content.config.ts`:
+
+  ```ts
+  {
+    title: string
+    description: string
+    date: Date
+    tldr: string[]          // hand-written summary bullets, Phase 5
+    notebook: string | undefined  // path to source .ipynb
+    archived: boolean       // true for all five 2022 posts
+    tags: string[]          // default []
+    draft: boolean          // default false
+  }
+  ```
+
+**Gate:** `npm run build` produces a `dist/`, and the Jekyll build still succeeds.
+
+### Phase 2 — Notebook conversion (highest risk — do it early)
+
+This is where surprises live. If something is going to derail the migration, it
+will be here, so it happens before any layout work.
+
+- `git mv _notebooks notebooks`.
+- Write `scripts/convert-notebooks.sh`: `jupyter nbconvert --to markdown`, one
+  output directory per post, images extracted to real files alongside the `.md`.
+- Take front matter (`title`, `description`, date) from the **existing**
+  `_posts/*.md` files — it is already correct there. Do not re-derive it from
+  the notebooks.
+- Post-process: fix image paths, strip nbconvert artifacts, drop the leftover
+  `keywords: fastai` field.
+- Run once, commit the output. The script is kept for reference; **it does not
+  run in CI**.
+
+Check each of the five posts for: LaTeX math, syntax-highlighted code, matplotlib
+plots, pandas HTML tables, and long output blocks.
+
+**Gate:** all five posts exist as Markdown, no base64 remains in
+`src/content/posts/`, and the total size of the five posts is well under the
+~1.9 MB the current `_posts/` occupies.
+
+### Phase 3 — Routes and layouts
+
+- Base layout: `<head>`, nav, footer, GA4.
+- Post layout, page layout.
+- Post route generating the `.html` URLs from Appendix A. Note the site mixes
+  formats: posts are `/…/slug.html`, pages are `/about/`. Get the mechanism
+  from the Astro docs; the parity test in Phase 6 is what proves it correct.
+- Pages: `/` (home), `/about/`, `/contact/`, `/search/`, `/404.html`.
+- Port About and Contact prose verbatim from `_pages/`.
+
+**Gate:** every path in `tests/expected-urls.json` exists in `dist/`.
+
+### Phase 4 — Feature parity
+
+- `feed.xml` (`@astrojs/rss`), `sitemap.xml`, `robots.txt`, `CNAME` in `public/`.
+- SEO meta + Open Graph (replaces `jekyll-seo-tag`).
+- Pagefind search on `/search/`.
+- Math CSS.
+- Styles: readable measure, code blocks, tables, figures with captions.
+  Self-host what you need — **drop the Primer and FontAwesome CDN links**
+  currently in `_includes/custom-head.html`.
+
+**Gate:** feed, sitemap and search all work in a local preview build.
+
+### Phase 5 — Improvements (agreed scope — nothing beyond this)
+
+- **Home page**: short intro + post list, replacing the current bare `# Posts`.
+- **TL;DR block** on each archived post: 3–5 bullets in the `tldr` front matter
+  field, rendered above the content. This is the "summarize" the user asked for.
+- **Archive note** on each 2022 post: one line, e.g. *"Written in 2022, when I
+  was moving from mathematics into industry. Left as it was."*
+- **Reading time** (currently commented out at `_layouts/post.html:39`).
+- **Dark mode**, respecting `prefers-color-scheme`.
+- **Image optimization** via Astro's `<Image>`.
+- **Tags**: add real tags to the five posts. Drop the dead category machinery.
+
+Ask before adding anything not on this list.
+
+### Phase 6 — Tests and docs
+
+Testing, proportionate to a five-post blog — these four, no more:
+
+1. `astro check` — types and content schema. Cheapest, catches the most.
+2. **URL parity** (`tests/urls.test.ts`) — assert `dist/` contains every path in
+   `expected-urls.json`. **This is the most important test in the repo.** It is
+   the thing standing between you and silently breaking every inbound link.
+3. **Smoke tests** (Playwright) — each page returns 200, has an `<h1>`, and logs
+   no console errors. Chromium is already available; do not run `playwright install`.
+4. **Internal link check** over `dist/` — catches bad paths from Phase 2.
+
+All four run in CI on every push to the branch.
+
+Docs — **hard budgets, high level, no edge-case specs**:
+
+| File | Budget | Content |
+|---|---|---|
+| `CLAUDE.md` | 3 lines | Points at `AGENTS.md`. Nothing else |
+| `AGENTS.md` | ≤ 60 lines | Commands, conventions, the invariants above, what not to touch |
+| `docs/code-map.md` | ≤ 60 lines | Directory-by-directory: what lives there and why. A reader should locate any file in under a minute |
+| `docs/decisions.md` | ≤ 40 lines | One short entry per decision: what, why, what it rules out |
+| `README.md` | ≤ 40 lines | What the site is, how to run it, how to add a post. Replaces the fastpages boilerplate |
+
+If a doc wants to exceed its budget, cut it instead.
+
+**Gate:** all four checks green; every doc within budget.
+
+### Phase 7 — Cutover (only with explicit user approval)
+
+- Replace `.github/workflows/ci.yaml` with an Astro build →
+  `actions/upload-pages-artifact` → `actions/deploy-pages` workflow.
+- Delete in one commit: `Gemfile`, `Gemfile.lock`, `_config.yml`, `_layouts/`,
+  `_includes/`, `_sass/`, `_plugins/`, `_posts/`, `_action_files/`,
+  `_fastpages_docs/`, `_word/`, `_pages/`, `docker-compose.yml`, `Makefile`,
+  `settings.ini`, `index.html`, `assets/`, `.devcontainer.json`, and the
+  `check_cdns`, `check_config`, `docker-nbdev`, `upgrade`, `gh-page` workflows.
+- Keep: `notebooks/`, `images/` (as needed), `CNAME`, `LICENSE`, `.gitattributes`.
+
+**Gate:** URL parity passes against the deleted-Jekyll build. Then hand back to
+the user for review and merge.
+
+### Phase 8 — Optional, after merge
+
+Connect the repo to Cloudflare Pages for per-branch preview URLs. Production
+stays on GitHub Pages. Purely additive; do not migrate hosting.
+
+---
+
+## Appendix A — URLs that must not break
+
+Extracted from the deployed `origin/gh-pages` branch, so this is what is
+actually live, not an inference.
+
+```
+/
+/2022/03/19/grades-analysis.html
+/2022/03/19/podcasts-recommender.html
+/2022/04/11/titanic-leak.html
+/2022/10/21/bert-fine-tune-podcast-reviews.html
+/2022/10/21/vader-bert-podcast-reviews.html
+/about/
+/contact/
+/search/
+/404.html
+/feed.xml
+/sitemap.xml
+/robots.txt
+```
+
+Note the two formats: posts end in `.html`, pages use trailing slashes. Both
+must be preserved exactly. There are no pagination or category pages — the
+`categories` layout exists in the Jekyll source but was never published.
+
+## Appendix B — Known quirks in the current site
+
+Things you will encounter; all are fixed by the phases above.
+
+- `_includes/custom-head.html` loads **both** KaTeX *and* MathJax 2.7.5, plus
+  `kramdown: math_engine: katex` in `_config.yml`. Three math paths for one job.
+  Phase 4 replaces all of it with build-time rendering.
+- Primer CSS and FontAwesome load from CDN; a whole workflow
+  (`check_cdns.yaml`) exists to watch them. Self-hosting removes both.
+- Client-side JS wraps images in `<figure>` and injects anchor icons. Do this at
+  build time instead.
+- `settings.ini` is unmodified nbdev boilerplate — `lib_name = nbdev`,
+  `author = Sylvain Gugger and Jeremy Howard`, `baseurl = /my-blog`. Never used
+  by anything that matters. Delete it.
+- `_layouts/default.html` does not exist locally; it comes from
+  `remote_theme: jekyll/minima@69664442…`, pinned to a 2020 commit and fetched
+  at build time. Astro replaces it with a local layout.
+- `_posts/*.md` are nbconvert output, not hand-written. Nothing there is
+  authored content — the `.ipynb` files are.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,8 +1,10 @@
 # Migration plan: fastpages/Jekyll → Astro
 
-**Status:** not started
-**Branch:** `claude/portfolio-framework-recommendations-qnclw1`
-**Audience:** the implementer (human or agent).
+**Status:** not started. Next: Phase 0.
+**Audience:** the implementer (human or agent). Start with `/migrate`.
+
+The Status line above is the handoff signal — keep it in the form
+`Phase N complete. Next: Phase N+1.` so the next agent can read it.
 
 This file is a *work order*, not permanent documentation. It is prescriptive on
 purpose. Delete it once the migration lands. The docs it tells you to write
@@ -52,7 +54,9 @@ do not silently substitute an alternative.
 - Do not re-execute notebooks or install pandas/torch/transformers.
 - Do not change any URL in Appendix A.
 - Do not delete Jekyll files before Phase 7.
-- Do not open a pull request unless the user asks.
+- Do not merge anything, and do not push to `master`. End your phase with a
+  pull request and leave it open. Do not open PRs mid-phase, and do not include
+  work from a phase you were not assigned.
 - Do not add an SSR adapter, server endpoints, or Cloudflare config. Static only.
 - Do not redesign wholesale. Improvements in Phase 5 are the agreed scope.
 - Do not write docs longer than the budgets in Phase 6.
@@ -87,15 +91,42 @@ astro.config.mjs  package.json  .nvmrc
 Each phase ends with a **gate**. Do not start the next phase until the gate
 passes. Commit at every gate.
 
-### Phase 0 — Baseline
+**One agent per group, in sequence — never two at once.** The groups below are
+context boundaries, not parallel tracks: the dependency graph is close to
+linear, and a fresh agent starting from these docs beats one carrying 600 KB of
+notebook JSON in its context. Each group ends with a pull request; the owner
+reviews and merges before the next begins.
+
+| Agent | Phases |
+|---|---|
+| A | 0–1 — baseline, parity test, scaffold |
+| B | 2 — notebook conversion, isolated and context-heavy |
+| C | 3–4 — routes, layouts, feature parity |
+| D | 5–6 — improvements, tests, docs |
+| E | 7 — cutover, only once approved |
+
+Do not split a phase across agents. In particular, do not convert the five
+notebooks with five agents: the conversion script is written once and run five
+times, or you get five inconsistent conversions.
+
+### Phase 0 — Baseline and the parity test
 
 - Fetch `origin/gh-pages` (the currently deployed output) into a scratch dir.
   It is the ground truth for both URLs and rendered appearance.
 - Save the URL list from Appendix A as `tests/expected-urls.json`.
 - Save a copy of one rendered post (e.g. `2022/03/19/grades-analysis.html`) for
   visual comparison later.
+- **Write `tests/urls.test.ts` now**, asserting that every path in
+  `expected-urls.json` exists in `dist/`. It will fail — there is no `dist/`
+  yet. That is correct; commit it red.
 
-**Gate:** `tests/expected-urls.json` exists and contains 13 paths.
+The test is written here, before any routing exists, and by a different agent
+than the one that builds the routes. If the agent building routes also writes
+the test that checks them, a misreading of the URL scheme lands in both and the
+test passes while every inbound link breaks.
+
+**Gate:** `tests/expected-urls.json` contains the 13 paths from Appendix A, and
+`tests/urls.test.ts` exists.
 
 ### Phase 1 — Scaffold Astro alongside Jekyll
 
@@ -121,7 +152,9 @@ Astro and Jekyll can coexist: Astro owns `src/`, `public/`, `astro.config.mjs`,
   }
   ```
 
-**Gate:** `npm run build` produces a `dist/`, and the Jekyll build still succeeds.
+**Gate:** `npm run build` produces a `dist/`, the Jekyll build still succeeds,
+and the parity test runs and fails for the right reason — missing routes, not a
+syntax error.
 
 ### Phase 2 — Notebook conversion (highest risk — do it early)
 
@@ -156,7 +189,8 @@ plots, pandas HTML tables, and long output blocks.
 - Pages: `/` (home), `/about/`, `/contact/`, `/search/`, `/404.html`.
 - Port About and Contact prose verbatim from `_pages/`.
 
-**Gate:** every path in `tests/expected-urls.json` exists in `dist/`.
+**Gate:** the parity test from Phase 0 passes. Do not edit that test to make it
+pass — if it disagrees with your routes, your routes are wrong.
 
 ### Phase 4 — Feature parity
 
@@ -189,9 +223,9 @@ Ask before adding anything not on this list.
 Testing, proportionate to a five-post blog — these four, no more:
 
 1. `astro check` — types and content schema. Cheapest, catches the most.
-2. **URL parity** (`tests/urls.test.ts`) — assert `dist/` contains every path in
-   `expected-urls.json`. **This is the most important test in the repo.** It is
-   the thing standing between you and silently breaking every inbound link.
+2. **URL parity** — already written in Phase 0 and passing since Phase 3. Wire
+   it into CI here. It is the most important test in the repo: the thing between
+   you and silently breaking every inbound link.
 3. **Smoke tests** (Playwright) — each page returns 200, has an `<h1>`, and logs
    no console errors. Chromium is already available; do not run `playwright install`.
 4. **Internal link check** over `dist/` — catches bad paths from Phase 2.
@@ -277,3 +311,19 @@ Things you will encounter; all are fixed by the phases above.
   at build time. Astro replaces it with a local layout.
 - `_posts/*.md` are nbconvert output, not hand-written. Nothing there is
   authored content — the `.ipynb` files are.
+
+---
+
+## Handoff log
+
+**This log is the handoff between agents**, not the pull request descriptions —
+it arrives in `master` when a phase's PR merges, so the next agent finds it by
+reading the repo. PR descriptions are written for the owner.
+
+One entry per phase, appended at the end. **Ten lines maximum each.** Only
+three things: what differed from the plan, what the next agent needs to know,
+and anything left broken. If a step in the plan was wrong, fix the step — do
+not describe the discrepancy here.
+
+<!-- Phase 0: -->
+


### PR DESCRIPTION
Documentation only — no build or site changes. The Jekyll site continues to publish exactly as before.

This lands the plan and conventions for replacing the deprecated fastpages/Jekyll build with Astro, so that the implementation work can start from a merged contract rather than carrying the plan along on its own branch.

## Why now

The site is built by [fastpages](https://github.com/fastai/fastpages), deprecated since 2022. The build runs inside `docker://fastai/fastpages-jekyll@sha256:6db4173…`, an unmaintained image, on Ruby 2.7-era gems. If that image disappears the site cannot be rebuilt. The recent Nokogiri pin ("Use latest Nokogiri compatible with Ruby 2.7", 681b288) is a symptom of the same decay.

## What's here

| File | Purpose |
|---|---|
| `docs/migration-plan.md` | The work order: eight gated phases, pre-made decisions, explicit prohibitions |
| `AGENTS.md` | Commands, conventions, and four invariants an implementer must not break |
| `CLAUDE.md` | Three lines, pointing at `AGENTS.md` |
| `docs/code-map.md` | Target tree, plus the Jekyll files awaiting deletion |
| `docs/decisions.md` | Why Astro, why frozen notebooks, why GitHub Pages, why URLs are test-enforced |
| `README.md` | Replaces the leftover fastpages template boilerplate |

## The URL surface is pinned to reality

The most important input came from the deployed `origin/gh-pages` branch rather than from inference. It shows the site publishes 13 paths in **two different URL formats** — posts end in `.html` (`/2022/03/19/grades-analysis.html`), pages use trailing slashes (`/about/`). Both must survive the migration; these links appear on job applications.

That list is Appendix A of the plan, and becomes `tests/expected-urls.json` enforced by a parity test. The plan deliberately specifies the *invariant and its test* rather than the Astro routing mechanism, so correctness is proven by the build rather than by a recipe.

It also confirmed there are no pagination or category pages — the `categories` layout exists in the Jekyll source but was never published.

## Notes for review

- The docs describe the **target** structure, so parts are forward-looking until the migration lands. Each file is marked accordingly.
- Every doc has a line budget set in the plan and stays inside it. Notebooks were converted to Markdown once and are frozen; the plan forbids re-executing them, so no Python or 2022 ML dependencies enter the build.
- Deleting the Jekyll tree is Phase 7 and gated on explicit approval. Nothing in this PR removes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xFDiAT96b3dqrNmfiPbCp)_