### PR TITLE
Add plain-language fallback for /migrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ directories, `Gemfile`) still publishes the live site; the Astro tree (`src/`,
 last, and only with the owner's approval.
 
 Run a single phase with `/migrate`. **If that isn't recognized** — project
-skill registration can lag or fail in cloud sessions — paste this instead, it
-does the same thing:
+skill discovery can be lazy in cloud sessions, registering only once something
+reads the directory — try, in order:
 
-> Follow `.claude/skills/migrate/SKILL.md` to run the next migration phase.
+1. Ask Claude to check the repo for custom skills. This alone has fixed it.
+2. Paste directly: "Follow `.claude/skills/migrate/SKILL.md` to run the next
+   migration phase."
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,13 @@ How to work in this repo. Keep it this short.
 directories, `Gemfile`) still publishes the live site; the Astro tree (`src/`,
 `astro.config.mjs`) is being built alongside it. Phase order and gates:
 [`docs/migration-plan.md`](docs/migration-plan.md). The Jekyll tree is deleted
-last, and only with the owner's approval. Run a single phase with `/migrate`.
+last, and only with the owner's approval.
+
+Run a single phase with `/migrate`. **If that isn't recognized** — project
+skill registration can lag or fail in cloud sessions — paste this instead, it
+does the same thing:
+
+> Follow `.claude/skills/migrate/SKILL.md` to run the next migration phase.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,10 @@ directories, `Gemfile`) still publishes the live site; the Astro tree (`src/`,
 [`docs/migration-plan.md`](docs/migration-plan.md). The Jekyll tree is deleted
 last, and only with the owner's approval.
 
-Run a single phase with `/migrate`. **If that isn't recognized** — project
-skill discovery can be lazy in cloud sessions, registering only once something
-reads the directory — try, in order:
+Run a single phase with `/migrate`. **If a fresh session doesn't recognize
+it** — seen once, cause unconfirmed — try, in order:
 
-1. Ask Claude to check the repo for custom skills. This alone has fixed it.
+1. Ask Claude to check the repo for custom skills, or just retry `/migrate`.
 2. Paste directly: "Follow `.claude/skills/migrate/SKILL.md` to run the next
    migration phase."
 


### PR DESCRIPTION
A fresh cloud session initially reported `Unknown command: /migrate` despite the skill file being present on `master`. After being asked to check the repo for custom skills, it recognized the skill.

That doesn't actually match the documented behavior — cloud sessions are supposed to load project skills from `.claude/skills/` automatically at session start — so this PR does not claim a cause. One occurrence isn't enough to tell a race condition, a caching quirk, and "it would have worked on a plain retry too" apart, and there's no way to check from here.

`AGENTS.md` now states the symptom and two remedies without asserting why either works:

1. Ask Claude to check the repo for custom skills, or just retry `/migrate`.
2. Paste directly: "Follow `.claude/skills/migrate/SKILL.md` to run the next migration phase."

If it recurs, worth a `/bug` report with the transcript — that has visibility this session doesn't.