### PR TITLE
Phase 5: improvements — TL;DRs, tags, dark mode, home page, alt text

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,15 @@ export default defineConfig({
   site: 'https://david-recio.com',
   output: 'static',
   markdown: {
+    // Two Shiki themes rather than one. With `defaultColor: false` every token
+    // carries both colours as `--shiki-light` / `--shiki-dark` custom
+    // properties and the stylesheet picks one, so code follows
+    // `prefers-color-scheme` like the rest of the page. A single theme would
+    // leave code blocks the one element that ignores dark mode.
+    shikiConfig: {
+      themes: { light: 'github-light', dark: 'github-dark' },
+      defaultColor: false,
+    },
     // Math is rendered once, here, at build time. The Jekyll site loaded KaTeX,
     // MathJax and a kramdown math engine to do the same job in the browser;
     // this ships the resulting HTML plus `katex.min.css` and no JavaScript.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -28,7 +28,7 @@ arrives with the migration ([`migration-plan.md`](migration-plan.md)).
 |---|---|
 | `astro.config.mjs` | Integrations, Markdown pipeline, URL format |
 | `scripts/convert-notebooks.sh` | One-time `.ipynb` → Markdown. **Not run in CI.** It ran once; its output is committed. Installs its two dependencies, then runs the `.py` |
-| `scripts/convert-notebooks.py` | The conversion itself: drops fastpages `#hide` cells, folds `#collapse-*` into `<details>`, takes front matter from `_posts/` |
+| `scripts/convert-notebooks.py` | The conversion itself: drops fastpages `#hide` cells, folds `#collapse-*` into `<details>`, strips Colab's dataframe widgets, takes front matter from `_posts/` |
 | `scripts/nbtemplate/` | nbconvert template that emits those `<details>` wrappers |
 | `tests/expected-urls.json` | The published URL surface, taken from the live deployment |
 | `tests/` | URL parity, Playwright smoke tests, internal link check |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -64,3 +64,16 @@ serves files with no server-side redirects — so a changed path is a hard 404,
 not a redirect. Keeping the paths costs one build setting; replacing them would
 cost a stub page per old URL. It is pinned in `tests/expected-urls.json` and
 enforced by a test, rather than left to convention and good intentions.
+
+## Dark mode by `prefers-color-scheme`, and code in two themes
+
+No toggle: a toggle needs client-side JavaScript and a stored preference, and
+the OS already holds that preference. So the palette is one `@media` block of
+custom-property values and no extra rules.
+
+Shiki emits both `github-light` and `github-dark` per token (`defaultColor:
+false`) so code follows the scheme too. That also changed light mode, where
+code blocks had been dark on a white page.
+
+Costs: colours may only be defined in `:root` and that one media block —
+anything hard-coded elsewhere breaks in one scheme.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -442,12 +442,12 @@ after `astro build`, so **search is empty under `astro dev`**; use `npm run prev
 <!-- Phase 5: -->
 
 **Phase 5** — This phase had no gate; one is added above, matching the others.
-Colab leftovers survive in the two 2022-10-21 posts (a **Phase 2** miss): the
-`<style>` blocks are live CSS, and the `<script>` blocks are indented, so they
-render as a visible plaintext code block instead of executing. That means no
-console error — **the Phase 6 smoke test will not catch them.**
-Astro's `<Image>` was not needed: markdown images already build to sized, lazy
-webp, so the work was the 31 alt texts. Tags are labels, not links — no tag
-pages, so no new URLs. Colours now live only in `:root` and one
-`prefers-color-scheme` block; a literal hex anywhere else breaks one scheme.
+Colab wraps every dataframe in a widget (container div, button, unscoped
+`<style>`, a `<script>` calling `google.colab`) and it survived Phase 2 into the
+two 2022-10-21 posts. Fixed here at the owner's request: `COLAB_TABLE` in
+`scripts/convert-notebooks.py` keeps the table and drops the widget, and the
+committed posts were rewritten with that same regex.
+`<Image>` was not needed — markdown images already build to sized, lazy webp, so
+the work was the 31 alt texts. Tags are labels, not links: no tag pages, no new
+URLs. Colours live only in `:root` and one `prefers-color-scheme` block.
 `docs/decisions.md` is 79 lines against its 40-line budget — cut in Phase 6.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,6 +1,6 @@
 # Migration plan: fastpages/Jekyll → Astro
 
-**Status:** Phase 4 complete. Next: Phase 5.
+**Status:** Phase 5 complete. Next: Phase 6.
 **Audience:** the implementer (human or agent). Start with `/migrate`.
 
 The Status line above is the handoff signal — keep it in the form
@@ -257,6 +257,9 @@ paths green.
 
 Ask before adding anything not on this list.
 
+**Gate:** `astro check` clean, the parity test still green in full, and every
+item above visible in a preview build under both colour schemes.
+
 ### Phase 6 — Tests and docs
 
 Testing, proportionate to a five-post blog — these four, no more:
@@ -435,3 +438,16 @@ Math plugins go through `processor: unified({...})` from `@astrojs/markdown-rema
 single lines in grades-analysis, which remark-math renders inline, not display — the
 delimiters were rewrapped (no math or prose changed). Pagefind (Component UI) indexes
 after `astro build`, so **search is empty under `astro dev`**; use `npm run preview`.
+
+<!-- Phase 5: -->
+
+**Phase 5** — This phase had no gate; one is added above, matching the others.
+Colab leftovers survive in the two 2022-10-21 posts (a **Phase 2** miss): the
+`<style>` blocks are live CSS, and the `<script>` blocks are indented, so they
+render as a visible plaintext code block instead of executing. That means no
+console error — **the Phase 6 smoke test will not catch them.**
+Astro's `<Image>` was not needed: markdown images already build to sized, lazy
+webp, so the work was the 31 alt texts. Tags are labels, not links — no tag
+pages, so no new URLs. Colours now live only in `:root` and one
+`prefers-color-scheme` block; a literal hex anywhere else breaks one scheme.
+`docs/decisions.md` is 79 lines against its 40-line budget — cut in Phase 6.

--- a/scripts/convert-notebooks.py
+++ b/scripts/convert-notebooks.py
@@ -20,6 +20,7 @@ import json
 import re
 import shutil
 import sys
+import textwrap
 from pathlib import Path
 
 import nbformat
@@ -46,6 +47,19 @@ ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 # pandas emits `<style scoped>` with every `to_html`. `scoped` was dropped from
 # the HTML spec, so these would apply site-wide rather than to their table.
 PANDAS_STYLE = re.compile(r"^<style scoped>.*?^</style>\n", re.DOTALL | re.MULTILINE)
+# The two 2022-10-21 notebooks were run in Google Colab, which wraps every
+# dataframe in a "convert to interactive table" widget: a container div, a
+# button, an unscoped `<style>` and a `<script>` calling `google.colab`. None of
+# it works outside Colab. Keep the table, drop the widget.
+COLAB_TABLE = re.compile(
+    r"^[ ]*<div id=\"df-[0-9a-f-]+\">\n"
+    r"[ ]*<div class=\"colab-df-container\">\n"
+    r"(?P<table>[ ]*<div>\n<table class=\"dataframe\">.*?</table>\n</div>)\n"
+    r".*?^[ ]*</script>\n"
+    r"[ ]*</div>\n"
+    r"[ ]*</div>",
+    re.DOTALL | re.MULTILINE,
+)
 IMAGE_REF = re.compile(r"!\[[^\]]*\]\((?P<path>[^)\s]+_files/[^)\s]+)\)")
 
 
@@ -170,6 +184,10 @@ def rewrite_images(body: str, resources: dict, post_dir: Path) -> str:
 def clean(body: str) -> str:
     body = ANSI.sub("", body)
     body = PANDAS_STYLE.sub("", body)
+    body = COLAB_TABLE.sub(
+        lambda m: textwrap.dedent(m.group("table").replace("      <div>", "<div>", 1)),
+        body,
+    )
     # `border="1"` is presentation, and it overrides the stylesheet.
     body = body.replace('<table border="1" class="dataframe">', '<table class="dataframe">')
     body = re.sub(r"\n{3,}", "\n\n", body)

--- a/src/content/posts/bert-fine-tune-podcast-reviews/index.md
+++ b/src/content/posts/bert-fine-tune-podcast-reviews/index.md
@@ -2041,9 +2041,7 @@ holdout_reviews['sentiment'] = (holdout_reviews['rating'] > 3).astype(int)
 pd.crosstab(holdout_reviews['sentiment pred mymodel'], holdout_reviews['sentiment'])
 ```
 
-  <div id="df-9bd5760a-642d-4a01-82a4-b63dcd80ac8e">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -2071,89 +2069,12 @@ pd.crosstab(holdout_reviews['sentiment pred mymodel'], holdout_reviews['sentimen
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-9bd5760a-642d-4a01-82a4-b63dcd80ac8e')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-9bd5760a-642d-4a01-82a4-b63dcd80ac8e button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-9bd5760a-642d-4a01-82a4-b63dcd80ac8e');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 ```python
 pd.crosstab(holdout_reviews['sentiment pred sstmodel'], holdout_reviews['sentiment'])
 ```
 
-  <div id="df-98668af1-c4e4-4051-bba8-97600dc3eec4">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -2181,81 +2102,6 @@ pd.crosstab(holdout_reviews['sentiment pred sstmodel'], holdout_reviews['sentime
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-98668af1-c4e4-4051-bba8-97600dc3eec4')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-98668af1-c4e4-4051-bba8-97600dc3eec4 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-98668af1-c4e4-4051-bba8-97600dc3eec4');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 Clearly the results are way better for our model than the model fine-tuned on SST2. The latter does much worse on these held out reviews than for the generic reviews. I swear I didn't cherry pick them to make our model look good! But I did pick some of them because they seemed like interesting examples that are particular to the context of podcast reviews.
 
@@ -2267,9 +2113,7 @@ First there are two reviews for two different **horror themed podcasts**. I wond
 holdout_reviews.loc[[11204, 11211], ['review', 'rating', 'positive prob mymodel', 'positive prob sstmodel', 'polarity score']]
 ```
 
-  <div id="df-06f2f90a-53a9-4fd6-9cd7-4bb5ff221950">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -2301,81 +2145,6 @@ holdout_reviews.loc[[11204, 11211], ['review', 'rating', 'positive prob mymodel'
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-06f2f90a-53a9-4fd6-9cd7-4bb5ff221950')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-06f2f90a-53a9-4fd6-9cd7-4bb5ff221950 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-06f2f90a-53a9-4fd6-9cd7-4bb5ff221950');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 ```python
 holdout_reviews.loc[11204, 'review']
@@ -2413,9 +2182,7 @@ Next there are two reviews discussing **sound issues**. Because this is a common
 holdout_reviews.loc[[9, 123052], ['rating', 'positive prob mymodel', 'positive prob sstmodel', 'polarity score']]
 ```
 
-  <div id="df-37cb415b-7a37-41af-b39d-2b471f0f43e3">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -2444,81 +2211,6 @@ holdout_reviews.loc[[9, 123052], ['rating', 'positive prob mymodel', 'positive p
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-37cb415b-7a37-41af-b39d-2b471f0f43e3')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-37cb415b-7a37-41af-b39d-2b471f0f43e3 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-37cb415b-7a37-41af-b39d-2b471f0f43e3');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 ```python
 holdout_reviews.loc[9, 'review']
@@ -2589,9 +2281,7 @@ Here is the whole holdout dataframe. I mostly went over the reviews in which the
 holdout_reviews[['review', 'rating', 'positive prob mymodel', 'positive prob sstmodel', 'polarity score']].head(17) # Making sure all 17 rows are shown
 ```
 
-  <div id="df-629a4f31-89fd-4ca1-9213-51fae0e816c2">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -2743,81 +2433,6 @@ holdout_reviews[['review', 'rating', 'positive prob mymodel', 'positive prob sst
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-629a4f31-89fd-4ca1-9213-51fae0e816c2')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-629a4f31-89fd-4ca1-9213-51fae0e816c2 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-629a4f31-89fd-4ca1-9213-51fae0e816c2');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 ## 6. On Model Confidence
 Something that jumps out when looking at the distributions of predicted probabilities is that the distilBERT fine-tuned on SST2 is *more confident* of its predictions than our model. The former mostly assigns probabilities close to 0 and 1 whereas the latter outputs more probabilities in between.

--- a/src/content/posts/bert-fine-tune-podcast-reviews/index.md
+++ b/src/content/posts/bert-fine-tune-podcast-reviews/index.md
@@ -1939,7 +1939,7 @@ evaluate_and_plot(
      'recall': array([0.66078431, 0.44008056, 0.46909828, 0.52818991, 0.84428716])}
 
     
-![](./output_47_2.png)
+![A five-by-five grid of histograms of predicted rating probabilities at the 17,000-step checkpoint, one row per true star rating.](./output_47_2.png)
     
 
 We see both in the recall and in the histograms that the model has a particularly hard time with 2 and 3 star ratings.
@@ -1970,7 +1970,7 @@ evaluate_and_plot(
     {'accuracy': 0.8828, 'recall': array([0.89533333, 0.864     ])}
 
     
-![](./output_50_2.png)
+![Two histograms of the predicted probability that a review is positive at the 17,000-step checkpoint, split by true sentiment.](./output_50_2.png)
     
 
 Now we evaluate the model which was fine-tuned on SST2 and is available on Hugging Face.
@@ -1989,7 +1989,7 @@ evaluate_and_plot(
     {'accuracy': 0.8148, 'recall': array([0.81466667, 0.815     ])}
 
     
-![](./output_52_2.png)
+![Two histograms of the predicted probability that a review is positive for the distilBERT fine-tuned on SST2, split by true sentiment.](./output_52_2.png)
     
 
 The model fine-tuned on SST has a lower accuracy $0.815$ and also lower recall scores of $0.815$ and $0.815$. It is remarkable how similar the recall scores of positive and negative ratings are for the distilBERT model fine-tuned on SST. After rounding they are actually identical.
@@ -2842,7 +2842,7 @@ evaluate_and_plot(
      'recall': array([0.60588235, 0.50151057, 0.51874367, 0.36597428, 0.84226491])}
 
     
-![](./output_82_2.png)
+![A five-by-five grid of histograms of predicted rating probabilities at the 6,000-step checkpoint, one row per true star rating. The distributions are noticeably more spread out than at 17,000 steps.](./output_82_2.png)
     
 
 ```python
@@ -2859,7 +2859,7 @@ evaluate_and_plot(
      'recall': array([0.59117647, 0.48539778, 0.44883485, 0.53610287, 0.79271992])}
 
     
-![](./output_83_2.png)
+![A five-by-five grid of histograms of predicted rating probabilities at the 40,000-step checkpoint, one row per true star rating. The distributions are far more concentrated at zero and one.](./output_83_2.png)
     
 
 ```python
@@ -2876,7 +2876,7 @@ evaluate_and_plot(
     {'accuracy': 0.8744, 'recall': array([0.93233333, 0.7875    ])}
 
     
-![](./output_84_2.png)
+![Two histograms of the predicted probability that a review is positive at the 6,000-step checkpoint, split by true sentiment.](./output_84_2.png)
     
 
 ```python
@@ -2893,4 +2893,4 @@ evaluate_and_plot(
     {'accuracy': 0.8762, 'recall': array([0.895, 0.848])}
 
     
-![](./output_85_2.png)
+![Two histograms of the predicted probability that a review is positive at the 40,000-step checkpoint, split by true sentiment.](./output_85_2.png)

--- a/src/content/posts/bert-fine-tune-podcast-reviews/index.md
+++ b/src/content/posts/bert-fine-tune-podcast-reviews/index.md
@@ -4,6 +4,25 @@ description: "In this post we will use the Hugging Face API and PyTorch to fine-
 date: 2022-10-21
 notebook: "notebooks/2022-10-21-bert-fine-tune-podcast-reviews.ipynb"
 archived: true
+tags: ["NLP", "BERT", "transformers", "fine-tuning", "Ray Tune"]
+tldr:
+  - "Fine-tunes base distilBERT on 80,000 podcast reviews to predict the star
+    rating from the review's title and body, with Ray Tune searching the
+    hyperparameters. Collapsing the five predicted ratings to two gives a
+    sentiment classifier for free."
+  - "On a 5,000-review test set balanced across ratings, that model reaches
+    0.883 sentiment accuracy against 0.815 for the off-the-shelf distilBERT
+    fine-tuned on SST2 — a real gain for roughly two epochs of training."
+  - "Predicting the star rating itself, all five classes, is much harder:
+    0.589. The stars are noisy labels, and neighbouring ones especially so."
+  - "Fine-tuning buys domain knowledge, not just fit. The model picks up
+    conventions specific to podcast reviews — reviews of horror podcasts use
+    language that reads as negative in general English while plainly approving
+    of the show."
+  - "Confidence is not accuracy. Trained on to 40,000 steps (4 epochs) the
+    output probabilities pile up at 0 and 1 while the evaluation loss climbs
+    and accuracy falls below the 17,000-step checkpoint. The post reads that
+    sharpening as a symptom of overfitting rather than a sign of learning."
 ---
 
 In a previous notebook we compared the performance of two methods to classify podcast reviews by sentiment. The VADER polarity score and a distilBERT transformer fine-tuned on the SST2 dataset, which consists of sentences from movie reviews.

--- a/src/content/posts/grades-analysis/index.md
+++ b/src/content/posts/grades-analysis/index.md
@@ -363,7 +363,7 @@ ax.hist(all_sections.grades, bins='auto');
 ```
 
     
-![](./output_29_0.png)
+![Histogram of the pooled final grades from all three sections, clearly skewed to the left.](./output_29_0.png)
     
 
 The data appears to have a clear left skew and thus does not look normal (more on that below). This made wonder why the data would differ from normality in this way and if this is a typical grade distribution for an exam. I found a 2019 [paper](https://stanford.edu/~cpiech/bio/papers/gradesAreNotNormal.pdf) (citation below), in which the authors analyzed 4000 assignments graded on Gradescope and essentially determined that most of the grade distributions were too skewed to be normal. Interestingly, the skewness was usually negative, just as in our case. They found the logit-normal distribution to be a good fit for exam grade distributions.
@@ -404,7 +404,7 @@ axs[2, 1].set_title('Synthetic normal data with large groups residuals');
 ```
 
     
-![](./output_32_0.png)
+![A three-by-two grid of histograms. Each row pairs a grade distribution with the residuals estimated from it: Section 1, synthetic normal data with small groups, and synthetic normal data with ten groups of eight.](./output_32_0.png)
     
 
 The histograms seem to make clear that the empirical distributions of the residuals (pictured on the right) are not a good approximation of the underlying distribution (pictured on the left). This holds also for the synthetic data. **These small sample effects might explain the low power of the bootstrap we will observe in the simulations below and why the power of the bootstrap converges with the other tests for larger group sizes.**
@@ -423,7 +423,7 @@ print(f'The sample skew is {st.skew(all_sections.grades)} and the sample kurtosi
     The sample skew is -1.0902692480611051 and the sample kurtosis is 1.3753992488399467.
 
     
-![](./output_35_1.png)
+![QQ plot of the pooled grades against a normal distribution. The points bend away from the reference line at both tails.](./output_35_1.png)
     
 
 Now we compute compute the sample skew and kurtosis for a random sample of a normal distribution, as a reference for our data. We also look at the QQ plot.
@@ -437,7 +437,7 @@ print(f'The sample skew is {st.skew(normal_sample)} and the sample kurtosis is {
     The sample skew is -0.1817125808235642 and the sample kurtosis is -0.34271547675743186.
 
     
-![](./output_37_1.png)
+![QQ plot of a random sample of 110 points drawn from a normal distribution, shown as a reference. The points follow the line closely.](./output_37_1.png)
     
 
 After running the cell above a couple of times, it is evident that a sample skew of -1 and a sample kurtosis of 1.4 are very unlikely for data sampled from a normal distribution. What this means is that the the grades distribution is skewed to the left (as we observed above) and has a longer tails than the normal distribution (a long *left* tail, really).
@@ -651,7 +651,7 @@ print(f'The median of the group means is {central_mean} and the median of the gr
     The median of the group means is 86.5875 and the median of the group standard deviations is 6.331982950879348.
 
     
-![](./output_57_1.png)
+![Two histograms side by side: the means of every group across all three sections, and their standard deviations.](./output_57_1.png)
     
 
 ```python
@@ -763,7 +763,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_63_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, equal means, equal standard deviations, normal data.](./output_63_2.png)
     
 
 Firstly, the permutation test and the uncorrected F-test (ANOVA) have almost identical p-values and they are also performing the best by far. Their rejection rates are just under the level $0.05$, which is perfect. The distributions look uniformly distributed.
@@ -792,7 +792,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_65_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of ten, equal means, equal standard deviations, normal data.](./output_65_2.png)
     
 
 From what we have seen above, it seems that the bootstrap and Welch F-test are not performing well for the small group sizes present in our data (around 4), while doing reasonably well for size 10 groups. The permutation test and the regular uncorrected F-test (one-way ANOVA) are still the best but not by much.
@@ -817,7 +817,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_67_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, equal means, equal standard deviations, empirical-distribution data.](./output_67_2.png)
     
 
 Now let's make the groups larger again.
@@ -840,7 +840,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_69_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of ten, equal means, equal standard deviations, empirical-distribution data.](./output_69_2.png)
     
 
 We can see that the empirical distribution and the normal distribution yield pretty results. The biggest difference is for the Welch F-test, which has an even worse rejection rate for the empirical distribution. This might be due to the long left tail. **We will only use the empirical distribution function from now on.**
@@ -869,7 +869,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_72_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, equal means, weakly varying standard deviations, empirical-distribution data.](./output_72_2.png)
     
 
 The p-values are almost identical to the case with constant standard deviation. They are very slightly larger in this case (as was expected) but not significantly. The same is true for **larger group sizes**:
@@ -892,7 +892,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_74_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of ten, equal means, weakly varying standard deviations, empirical-distribution data.](./output_74_2.png)
     
 
 If we let the **standard deviation vary strongly** between the groups something interesting happens: some p-value distributions have a peak at 1 as well as the usual peak at 0. This is the case also for very large group sizes. For instance, we let the groups be of size 50 below, which is much larger than the groups we have been considering. The peaks do not seem to change much as we vary the group sizes from 4 to 10 to 50.
@@ -917,7 +917,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_76_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, equal means, strongly varying standard deviations, empirical-distribution data.](./output_76_2.png)
     
 
 ```python
@@ -940,7 +940,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_77_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of fifty, equal means, strongly varying standard deviations, empirical-distribution data.](./output_77_2.png)
     
 
 #### Unequal means
@@ -967,7 +967,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_79_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, weakly varying means, equal standard deviations, empirical-distribution data.](./output_79_2.png)
     
 
 We see that the tests are very weak in this case, due to the small effect size (weakly varying means) and the small group sizes. The bootstrap is still performing terribly and the permutation tests and ANOVA rejection rates are barely higher than the level of the test.
@@ -994,7 +994,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_81_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of ten, weakly varying means, equal standard deviations, empirical-distribution data.](./output_81_2.png)
     
 
 Leaving the Welch F-test aside, the power has increased for larger groups, but it is still not great. It is worth noting that the bootstrap now yields almost the same p-value distribution as the permutation test and regular F-test, underscoring how the bootstrap does fine for larger groups, but just can't deal with the small groups in our data.
@@ -1019,7 +1019,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_84_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, strongly varying means, equal standard deviations, empirical-distribution data.](./output_84_2.png)
     
 
 ```python
@@ -1040,7 +1040,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_85_2.png)
+![P-value histograms for the four tests over 10,000 simulations: ten groups of ten, strongly varying means, equal standard deviations, empirical-distribution data.](./output_85_2.png)
     
 
 As we can see, going from the middle $33\%$ group means to the middle $80\%$ group means made an enormous difference. At around $0.4$, the power is still not great.
@@ -1065,7 +1065,7 @@ pd.Series(dict(result[0]))
     dtype: float64
 
     
-![](./output_87_2.png)
+![P-value histograms for the four tests over 10,000 simulations: groups of about four, as in Section 1, very strongly varying means, equal standard deviations, empirical-distribution data.](./output_87_2.png)
     
 
 We see that in the extremely varying means scenario the power of all tests other than the bootstrap is reasonably good ($0.85$). Surprisingly, the Welch corrected F-test has a lower power that the uncorrected F-test in this case, even though in most other cases it had a higher power (even *too* high, for equal means).

--- a/src/content/posts/grades-analysis/index.md
+++ b/src/content/posts/grades-analysis/index.md
@@ -4,6 +4,24 @@ description: "We explore the possible effects of student groups on final grades.
 date: 2022-03-19
 notebook: "notebooks/2022-03-19-grades-analysis.ipynb"
 archived: true
+tags: ["statistics", "hypothesis testing", "bootstrap", "ANOVA", "simulation"]
+tldr:
+  - "Three sections of a flipped-classroom course, with students randomly
+    assigned to breakout groups of about four. The question: did the group you
+    landed in move your final grade?"
+  - "No — not detectably. Across four tests (permutation, semiparametric
+    bootstrap, ANOVA F, Welch F) the smallest p-value was 0.053, in Section 2.
+    Correcting for the three sections needs a rejection threshold around 0.15
+    before that counts, under Benjamini-Hochberg as well as Bonferroni."
+  - "That is a null result, not evidence of no effect. Simulation puts the
+    power of all four tests low at these group sizes: only an effect as large
+    as the observed spread in sample group means is reliably detected."
+  - "The semiparametric bootstrap is by far the weakest of the four at groups
+    of four, and catches up with the others at groups of ten — the group size
+    is the problem, not the method."
+  - "The permutation test and the uncorrected F-test tracked each other to
+    within 0.01 on all three sections, which suggests ANOVA holds up here
+    despite the grades being clearly left-skewed rather than normal."
 ---
 
 The Covid pandemic arrived in the US while I was a visiting professor at Lehigh University. Like many, we had to quickly adapt to a rapidly evolving situation and transition from a physical classroom one week to a fully virtual format the next. To capitalize on the situation, I implemented a flipped classroom with prerecorded lectures. This entailed the students working together on exercises over Zoom divided into breakout rooms. The breakout room groups were created at random for fairness and retained throughout the whole semester. The main rationale for not changing the groups is that the students needed time to get to know each other and figure out a team-based work flow (students in each group had to prepare shared answers on OneNote). However, the downside was that some groups worked together better than others.

--- a/src/content/posts/podcasts-recommender/index.md
+++ b/src/content/posts/podcasts-recommender/index.md
@@ -4,6 +4,26 @@ description: "We train a podcast recommender using matrix-based collaborative fi
 date: 2022-03-19
 notebook: "notebooks/2022-03-19-podcasts-recommender.ipynb"
 archived: true
+tags: ["recommender systems", "collaborative filtering", "ALS", "PCA", "podcasts"]
+tldr:
+  - "Nearly a million Apple Podcasts reviews from Kaggle, curated down to 933
+    podcasts and 10,607 users with 40,585 positive ratings — a sparse matrix,
+    about 0.4% filled."
+  - "Almost every rating is five stars, so the star values carry little signal.
+    The ratings are treated as *implicit* feedback instead — a preference plus
+    a confidence, with a missing rating read as weak evidence against — and
+    fitted with Alternating Least Squares."
+  - "That works: precision@1 of 9.3% against 2.9% for a recommend-the-most-
+    popular baseline, and the per-podcast similar-item lists look sensible by
+    eye."
+  - "Running PCA over the 50-dimensional podcast factors gives two readable
+    axes: the first runs from self-improvement to pure entertainment (true
+    crime at the far end), the second separates podcasts aimed at children from
+    those aimed at adults. Both fall out of ratings alone — the model never
+    sees a title, a description or a category."
+  - "The main caveat is the dataset: its curator confirmed that many of the
+    most popular podcasts were left out deliberately, and without knowing the
+    selection rule there is no correcting for the resulting sampling bias."
 ---
 
 Nowadays we encounter recommender systems on a daily basis in search engines, streaming platforms, and social media. There exist many different mechanisms behind recommender systems, but we will focus on a a class of methods known as **collaborative filtering**. In a nutshell, this approach consists of taking the set of all known user preferences and using that to "predict" the user's preference for an **item** (movie, song, news article) that the user hasn't seen yet (or for which the user hasn't indicated a preference). The basis for establishing this preference depends on the context. Some examples include user ratings on Netflix, or how many times a user has listened to a song on Spotify.

--- a/src/content/posts/podcasts-recommender/index.md
+++ b/src/content/posts/podcasts-recommender/index.md
@@ -666,7 +666,7 @@ ax1.bar(ratings['rating'].value_counts().index, ratings['rating'].value_counts()
 ```
 
     
-![](./output_24_0.png)
+![Two bar charts of star-rating frequency, before and after curating the dataset. Five-star ratings dominate in both.](./output_24_0.png)
     
 
 ### Why Implicit?
@@ -851,7 +851,7 @@ for i, x, y in zip(podcast_names[top_podcasts], X, Y):
 ```
 
     
-![](./output_43_0.png)
+![Scatter plot of the twenty-five most reviewed podcasts, projected onto the first two principal components of the latent space and labelled by name.](./output_43_0.png)
     
 
 We must take the visualization with a grain of salt because obviously information is lost when we project a 50-dimensional space down to two dimensions. Specifically, podcasts that appear close in the projection might not be close at all in the full space.

--- a/src/content/posts/titanic-leak/index.md
+++ b/src/content/posts/titanic-leak/index.md
@@ -970,7 +970,7 @@ ax1.hist(survival_rates);
 </details>
 
     
-![](./output_73_0.png)
+![Two histograms over random train-test splits: the fraction of passenger groups divided between train and test, and the survival rate in the test set.](./output_73_0.png)
     
 
 The Kaggle test set seems to be very typical, at least as far as the survival rate and passenger groups are concerned. In fact, both values (0.61 and 0.38) are close to the mean for both distributions (almost suspiciously close). This suggests that the test set was either drawn at random or specifically chosen to have a typical survival rate.

--- a/src/content/posts/titanic-leak/index.md
+++ b/src/content/posts/titanic-leak/index.md
@@ -4,6 +4,27 @@ description: "We will explore a source of data leakage in the popular Titanic co
 date: 2022-04-11
 notebook: "notebooks/2022-04-11-titanic-leak.ipynb"
 archived: true
+tags: ["machine learning", "data leakage", "cross-validation", "XGBoost", "Kaggle"]
+tldr:
+  - "Passengers travelling together on the Titanic mostly lived or died
+    together, and Kaggle's train-test split cuts straight through those groups.
+    A model can therefore predict a passenger from the fate of their family in
+    the training set — information nobody would have had before the ship sank."
+  - "The fix is a leak-proof cross-validation: reconstruct the travelling
+    groups from names, tickets and cabins, then split so that a group is
+    entirely in train or entirely in test, never both."
+  - "With the leak closed, a tuned XGBoost still beats the baselines — 0.822
+    mean accuracy against 0.801 for the enhanced gender model and 0.780 for
+    predicting on sex alone. There is real signal in the data beyond the
+    leakage."
+  - "Given the chance, the model does seem to take it. With the truncated-ticket
+    feature its leaky-CV accuracy sits above its leak-proof accuracy, and
+    dropping that feature reverses the gap. Its whole advantage over the
+    baselines comes from passengers travelling in groups: on the 41% travelling
+    alone it only matches the baselines, or does worse."
+  - "The post's own caveat, kept here: most of these gaps are one to two
+    standard errors wide, so they are suggestive rather than settled. Paired
+    hypothesis tests across the folds are named as the next step."
 ---
 
 <details>

--- a/src/content/posts/vader-bert-podcast-reviews/index.md
+++ b/src/content/posts/vader-bert-podcast-reviews/index.md
@@ -306,7 +306,7 @@ plot_histograms_by_sentiment(reviews_raw, 'polarity score')
 ```
 
     
-![](./output_25_0.png)
+![Three histograms of the VADER polarity score, for reviews rated one or two stars, three stars, and four or five stars.](./output_25_0.png)
     
 
 The histograms clearly show a positivity bias. We see that even for negative ratings the mean sentiment score is just over 0:
@@ -767,7 +767,7 @@ plt.xlabel('Token count for review');
 ```
 
     
-![](./output_60_0.png)
+![Histogram of the token count per review, with most reviews well under 256 tokens.](./output_60_0.png)
     
 
 ```python
@@ -828,7 +828,7 @@ plot_histograms_by_sentiment(reviews, 'BERT probs')
 ```
 
     
-![](./output_68_0.png)
+![Two histograms of the probability distilBERT assigns to a review being positive, split by true sentiment. Both pile up sharply at zero and one.](./output_68_0.png)
     
 
 Most times when VADER and distilBERT disagree, the latter is right. This is not surprising because distilBERT is a much more complicated and computation intensive technique.

--- a/src/content/posts/vader-bert-podcast-reviews/index.md
+++ b/src/content/posts/vader-bert-podcast-reviews/index.md
@@ -137,9 +137,7 @@ reviews_raw = pd.read_pickle(os.path.join(PATH, 'data', 'reviews_raw_sentiment.p
 reviews_raw.head(2)
 ```
 
-  <div id="df-ec465d5c-c0e1-416f-8af1-653192915dfa">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -186,81 +184,6 @@ reviews_raw.head(2)
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-ec465d5c-c0e1-416f-8af1-653192915dfa')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-ec465d5c-c0e1-416f-8af1-653192915dfa button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-ec465d5c-c0e1-416f-8af1-653192915dfa');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 Having a look at the reviews, we see that VADER does catch some reviews that show the **user actually likes the podcast but has some minor complaint** to make. In that sense, one could use VADER to get the true user preference, which the rating is not reflecting correctly in those cases. 
 
@@ -414,9 +337,7 @@ The following is the confusion matrix for the whole (raw) dataset.
 pd.crosstab(reviews_raw['VADER sentiment'], reviews_raw['sentiment'])
 ```
 
-  <div id="df-df6e628f-e140-40ac-9b31-26524e3fc533">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -454,81 +375,6 @@ pd.crosstab(reviews_raw['VADER sentiment'], reviews_raw['sentiment'])
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-df6e628f-e140-40ac-9b31-26524e3fc533')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-df6e628f-e140-40ac-9b31-26524e3fc533 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-df6e628f-e140-40ac-9b31-26524e3fc533');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 ```python
 accuracy_score(reviews_raw['sentiment'], reviews_raw['VADER sentiment'])
@@ -552,9 +398,7 @@ The accuracy on the cleaned data in `reviews` is less misleading because we made
 pd.crosstab(reviews['VADER sentiment'], reviews['sentiment'])
 ```
 
-  <div id="df-89158054-9c1f-4fee-b046-228a9f8952a5">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -592,81 +436,6 @@ pd.crosstab(reviews['VADER sentiment'], reviews['sentiment'])
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-89158054-9c1f-4fee-b046-228a9f8952a5')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-89158054-9c1f-4fee-b046-228a9f8952a5 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-89158054-9c1f-4fee-b046-228a9f8952a5');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 We see that on `reviews` the accuracy is much lower but the recall is similar (it is a little lower but that might change if we choose different thresholds for the VADER score).
 
@@ -888,9 +657,7 @@ Here are some 3 star reviews that distilBERT classifies as positive.
 reviews[(reviews['BERT probs'] > 0.99) & (reviews['rating'] == 3)][['title', 'content', 'rating', 'polarity score', 'BERT probs']].head(10)
 ```
 
-  <div id="df-b5fce6e9-4284-4542-a08d-28e153e0adff">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -986,81 +753,6 @@ reviews[(reviews['BERT probs'] > 0.99) & (reviews['rating'] == 3)][['title', 'co
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-b5fce6e9-4284-4542-a08d-28e153e0adff')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-b5fce6e9-4284-4542-a08d-28e153e0adff button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-b5fce6e9-4284-4542-a08d-28e153e0adff');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 On the other hand, here is an example of a 3 star review that distilBERT classifies as negative.
 
@@ -1068,9 +760,7 @@ On the other hand, here is an example of a 3 star review that distilBERT classif
 reviews[(reviews['BERT probs'] < 0.01) & (reviews['rating'] == 3)][['title', 'content', 'rating', 'polarity score', 'BERT probs']].head(10)
 ```
 
-  <div id="df-3f3cd571-33fb-4ece-8b62-e03c2f845809">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -1166,81 +856,6 @@ reviews[(reviews['BERT probs'] < 0.01) & (reviews['rating'] == 3)][['title', 'co
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-3f3cd571-33fb-4ece-8b62-e03c2f845809')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-3f3cd571-33fb-4ece-8b62-e03c2f845809 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-3f3cd571-33fb-4ece-8b62-e03c2f845809');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 Looking at the reviews, there is a clear difference between the ones classified as positive and those classified as negative, even though all of them come with 3 star ratings. **This exemplifies one way in which the review sentiment can give us additional signal of user preference.**
 
@@ -1250,9 +865,7 @@ Now let's look at 1 and 2 star rating reviews that distilBERT classifies as posi
 reviews[(reviews['BERT probs'] > 0.99) & reviews['rating'].isin([1, 2])][['title', 'content', 'rating', 'polarity score', 'BERT probs']].head(10)
 ```
 
-  <div id="df-87413c99-9f63-4b51-861d-c2a8bedd486c">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -1348,81 +961,6 @@ reviews[(reviews['BERT probs'] > 0.99) & reviews['rating'].isin([1, 2])][['title
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-87413c99-9f63-4b51-861d-c2a8bedd486c')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-87413c99-9f63-4b51-861d-c2a8bedd486c button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-87413c99-9f63-4b51-861d-c2a8bedd486c');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>
 
 Finally these are some 4 and 5 star rating reviews that distilBERt classifies as negative. We can see that it is mostly 4 star reviews and furthermore they all seem to be complaining. It makes sense that distilBERT would classify them as negative.
 
@@ -1430,9 +968,7 @@ Finally these are some 4 and 5 star rating reviews that distilBERt classifies as
 reviews[(reviews['BERT probs'] < 0.01) & reviews['rating'].isin([4, 5])][['title', 'content', 'rating', 'polarity score', 'BERT probs']].head(10)
 ```
 
-  <div id="df-0316346f-58f5-4472-8a9e-9e1b1dfa8209">
-    <div class="colab-df-container">
-      <div>
+<div>
 <table class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -1528,78 +1064,3 @@ reviews[(reviews['BERT probs'] < 0.01) & reviews['rating'].isin([4, 5])][['title
   </tbody>
 </table>
 </div>
-      <button class="colab-df-convert" onclick="convertToInteractive('df-0316346f-58f5-4472-8a9e-9e1b1dfa8209')"
-              title="Convert this dataframe to an interactive table."
-              style="display:none;">
-
-  <svg xmlns="http://www.w3.org/2000/svg" height="24px"viewBox="0 0 24 24"
-       width="24px">
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z"/><path d="M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z"/>
-  </svg>
-      </button>
-
-  <style>
-    .colab-df-container {
-      display:flex;
-      flex-wrap:wrap;
-      gap: 12px;
-    }
-
-    .colab-df-convert {
-      background-color: #E8F0FE;
-      border: none;
-      border-radius: 50%;
-      cursor: pointer;
-      display: none;
-      fill: #1967D2;
-      height: 32px;
-      padding: 0 0 0 0;
-      width: 32px;
-    }
-
-    .colab-df-convert:hover {
-      background-color: #E2EBFA;
-      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);
-      fill: #174EA6;
-    }
-
-    [theme=dark] .colab-df-convert {
-      background-color: #3B4455;
-      fill: #D2E3FC;
-    }
-
-    [theme=dark] .colab-df-convert:hover {
-      background-color: #434B5C;
-      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);
-      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));
-      fill: #FFFFFF;
-    }
-  </style>
-
-      <script>
-        const buttonEl =
-          document.querySelector('#df-0316346f-58f5-4472-8a9e-9e1b1dfa8209 button.colab-df-convert');
-        buttonEl.style.display =
-          google.colab.kernel.accessAllowed ? 'block' : 'none';
-
-        async function convertToInteractive(key) {
-          const element = document.querySelector('#df-0316346f-58f5-4472-8a9e-9e1b1dfa8209');
-          const dataTable =
-            await google.colab.kernel.invokeFunction('convertToInteractive',
-                                                     [key], {});
-          if (!dataTable) return;
-
-          const docLinkHtml = 'Like what you see? Visit the ' +
-            '<a target="_blank" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'
-            + ' to learn more about interactive tables.';
-          element.innerHTML = '';
-          dataTable['output_type'] = 'display_data';
-          await google.colab.output.renderOutput(dataTable, element);
-          const docLink = document.createElement('div');
-          docLink.innerHTML = docLinkHtml;
-          element.appendChild(docLink);
-        }
-      </script>
-    </div>
-  </div>

--- a/src/content/posts/vader-bert-podcast-reviews/index.md
+++ b/src/content/posts/vader-bert-podcast-reviews/index.md
@@ -4,6 +4,27 @@ description: "In a previous post we trained a recommender on a million ratings f
 date: 2022-10-21
 notebook: "notebooks/2022-10-21-vader-bert-podcast-reviews.ipynb"
 archived: true
+tags: ["NLP", "sentiment analysis", "VADER", "BERT", "podcasts"]
+tldr:
+  - "Podcast reviews carry preference signal the star rating misses — a
+    one-star review is sometimes a fan complaining about the audio. This post
+    asks how much of that two off-the-shelf sentiment methods recover: VADER,
+    and a distilBERT already fine-tuned on SST2."
+  - "Scored against the ratings on a 100,000-review sample balanced at 20,000
+    per star, VADER manages 0.568 three-class accuracy, with recall of just
+    0.20 on the neutral (three-star) class. Collapsed to binary at the single
+    best possible threshold it reaches 0.718 — and that threshold is fitted on
+    the same data, so treat it as an optimistic baseline."
+  - "The two methods disagree most sharply on three-star reviews: VADER scores
+    them overwhelmingly positive, distilBERT calls them mostly negative.
+    Reading the reviews, the post sides with distilBERT and puts VADER's
+    behaviour down to a positivity bias."
+  - "Where they conflict, distilBERT is usually the one that is right. It reads
+    \"used to be a great comedy podcast, until…\" as negative, where VADER's
+    bag of words counts *great*, *wisdom* and *talent* and scores it 0.95."
+  - "It is not better at everything: distilBERT's probabilities pile up at 0
+    and 1, making it a confident binary classifier rather than a usable
+    continuous measure of sentiment. VADER is the better instrument for that."
 ---
 
 In another notebook we trained a recommender using collaborative filtering on a million ratings from Apple Podcasts. However, we didn't use the **content of the reviews**, which are an additional source of signal of user preference. Some of that signal can be extracted using **sentiment analysis** and could then be used to train a recommender system.

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,13 +1,14 @@
 ---
 import BaseLayout from './BaseLayout.astro';
-import { formatDate, type Post } from '../lib/posts';
+import { formatDate, readingTime, type Post } from '../lib/posts';
 
 interface Props {
   post: Post;
 }
 
 const { post } = Astro.props;
-const { title, description, date } = post.data;
+const { title, description, date, tldr, tags, archived } = post.data;
+const minutes = readingTime(post);
 ---
 
 <BaseLayout title={title} description={description} ogType="article" publishedDate={date}>
@@ -17,8 +18,47 @@ const { title, description, date } = post.data;
       <p class="page-description">{description}</p>
       <p class="post-meta">
         <time datetime={date.toISOString()}>{formatDate(date)}</time>
+        <span aria-hidden="true">·</span>
+        <span>{minutes} min read</span>
       </p>
+      {
+        tags.length > 0 && (
+          <ul class="tag-list" aria-label="Tags">
+            {tags.map((tag) => (
+              <li class="tag">{tag}</li>
+            ))}
+          </ul>
+        )
+      }
     </header>
+
+    {
+      /* Hand-written summary (front matter `tldr`), not extracted from the post.
+         Marked `data-pagefind-ignore` so search hits point at the prose that
+         makes the claim rather than at the bullet repeating it. */
+    }
+    {
+      tldr.length > 0 && (
+        <aside class="tldr" data-pagefind-ignore aria-labelledby="tldr-heading">
+          <h2 id="tldr-heading" class="tldr-heading">
+            TL;DR
+          </h2>
+          <ul>
+            {tldr.map((point) => (
+              <li>{point}</li>
+            ))}
+          </ul>
+        </aside>
+      )
+    }
+
+    {
+      archived && (
+        <p class="archive-note">
+          Written in 2022, when I was moving from mathematics into industry. Left as it was.
+        </p>
+      )
+    }
 
     <div class="post-content">
       <slot />

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -30,6 +30,23 @@ export async function getPublishedPosts(): Promise<Post[]> {
   return posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 }
 
+/**
+ * Estimated reading time in whole minutes, at 200 wpm.
+ *
+ * Counted over prose only: fenced code blocks and the `<details>` wrappers
+ * around them are stripped first. These are notebook posts, so counting the
+ * raw body would triple the estimate on the strength of dataframe dumps and
+ * import lists that nobody reads top to bottom.
+ */
+export function readingTime(post: Post): number {
+  const prose = post.body
+    ?.replace(/^```[\s\S]*?^```/gm, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+  const words = prose?.split(/\s+/).filter(Boolean).length ?? 0;
+  return Math.max(1, Math.round(words / 200));
+}
+
 /** `Mar 19, 2022` — the format the Jekyll site used, pinned to UTC. */
 export function formatDate(date: Date): string {
   return date.toLocaleDateString('en-US', {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,26 @@
 ---
 /**
- * Home. Deliberately as bare as the Jekyll home it replaces (`# Posts` plus
- * the post list) — the intro and the redesign are Phase 5.
+ * Home: a short intro, then the post list. Replaces the bare `# Posts` heading
+ * the Jekyll home had.
  */
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { formatDate, getPublishedPosts, postPath } from '../lib/posts';
+import { formatDate, getPublishedPosts, postPath, readingTime } from '../lib/posts';
 
 const posts = await getPublishedPosts();
 ---
 
 <BaseLayout title="David Recio's Blog">
   <div class="home">
-    <h1 class="page-heading">Posts</h1>
+    <h1 class="page-heading">Notebooks on statistics and machine learning</h1>
+
+    <p class="home-intro">
+      I&rsquo;m David &mdash; a former mathematician, now a software engineer in Boston. These
+      posts are from 2022, when I was making that move: hypothesis testing on my own students&rsquo;
+      grades, a podcast recommender built from a million reviews, data leakage in a Kaggle
+      competition, and two passes at sentiment analysis. <a href="/about/">More about me</a>.
+    </p>
+
+    <h2 class="post-list-heading">Posts</h2>
 
     <ul class="post-list">
       {
@@ -19,12 +28,14 @@ const posts = await getPublishedPosts();
           <li>
             <span class="post-meta">
               <time datetime={post.data.date.toISOString()}>{formatDate(post.data.date)}</time>
+              <span aria-hidden="true">·</span>
+              <span>{readingTime(post)} min read</span>
             </span>
-            <h2>
+            <h3>
               <a class="post-link" href={postPath(post)}>
                 {post.data.title}
               </a>
-            </h2>
+            </h3>
             <p class="post-description">{post.data.description}</p>
           </li>
         ))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -190,6 +190,22 @@ blockquote {
 
 /* Home -------------------------------------------------------------------- */
 
+.home-intro {
+  max-width: var(--measure);
+  font-size: 1.15rem;
+  color: var(--text-muted);
+}
+
+.post-list-heading {
+  margin-top: 3rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .post-list {
   list-style: none;
   padding: 0;
@@ -202,7 +218,7 @@ blockquote {
   border-top: 1px solid var(--border);
 }
 
-.post-list h2 {
+.post-list h3 {
   margin: 0.15em 0 0.35em;
   font-size: 1.4rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,8 +2,9 @@
  * The whole stylesheet. It replaces Primer (CDN) and FontAwesome (CDN), which
  * between them shipped ~200 KB to render a header, a post and a form.
  *
- * Dark mode is Phase 5 — the colours are already custom properties so that it
- * is a second block of values rather than a rewrite.
+ * Every colour is a custom property, so dark mode is the second block of
+ * values below and not a second set of rules. Nothing outside `:root` and the
+ * `prefers-color-scheme` block names a colour literally — keep it that way.
  */
 
 :root {
@@ -14,16 +15,39 @@
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
+  color-scheme: light dark;
+
   --text: #24292f;
   --text-muted: #57606a;
   --bg: #ffffff;
   --bg-subtle: #f6f8fa;
   --border: #d0d7de;
   --link: #0969da;
+  /* Text on a `--link` background — the primary button. */
+  --on-link: #ffffff;
   /* Search-hit highlight; the only place a background tint carries meaning. */
   --accent-mark: #fff3c4;
 
   --radius: 6px;
+}
+
+/*
+ * Dark mode. `prefers-color-scheme` only — there is no toggle, because a
+ * toggle needs client-side JavaScript and a stored preference, and the OS
+ * already carries that preference.
+ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text: #e6edf3;
+    --text-muted: #9198a1;
+    --bg: #0d1117;
+    --bg-subtle: #161b22;
+    --border: #30363d;
+    --link: #4493f8;
+    /* White on this blue is only ~3:1; the page background is not. */
+    --on-link: #0d1117;
+    --accent-mark: #57430a;
+  }
 }
 
 *,
@@ -216,6 +240,74 @@ blockquote {
   max-width: var(--measure);
 }
 
+.post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* Tags ---------------------------------------------------------------------
+ *
+ * Labels, not links: there are no tag index pages. The Jekyll site linked its
+ * categories at `/categories/#<slug>`, a page that was never published, so
+ * every one of those links 404'd. */
+
+.tag-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.9rem 0 0;
+  padding: 0;
+}
+
+.tag {
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.1rem 0.5rem;
+}
+
+/* TL;DR and archive note --------------------------------------------------- */
+
+.tldr {
+  max-width: var(--measure);
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.25rem 0.35rem;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.tldr-heading {
+  margin: 0 0 0.6em;
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.tldr ul {
+  margin: 0 0 1em;
+  padding-left: 1.2em;
+}
+
+.tldr li {
+  margin-bottom: 0.4em;
+}
+
+.archive-note {
+  max-width: var(--measure);
+  margin: 0 0 2.5rem;
+  padding-left: 1em;
+  border-left: 4px solid var(--border);
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
 /*
  * Posts hold two kinds of content at once. Prose wants a measure it is
  * comfortable to read; notebook output — code, dataframes, plots — is wider
@@ -268,6 +360,25 @@ pre:not([class]) {
   word-break: break-word;
 }
 
+/*
+ * Shiki emits both themes as custom properties per token (see
+ * `astro.config.mjs`); these two rules are what actually chooses one. Without
+ * them highlighted code renders unstyled.
+ */
+.astro-code,
+.astro-code span {
+  color: var(--shiki-light);
+  background-color: var(--shiki-light-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  .astro-code,
+  .astro-code span {
+    color: var(--shiki-dark);
+    background-color: var(--shiki-dark-bg);
+  }
+}
+
 /* Tables ------------------------------------------------------------------ */
 
 table {
@@ -303,6 +414,20 @@ figcaption {
   font-size: 0.9rem;
   color: var(--text-muted);
   text-align: center;
+}
+
+/*
+ * The matplotlib plots are PNGs with an opaque white canvas, so on a dark page
+ * they arrive as bare white slabs. Padding them onto a light card makes that
+ * read as deliberate. Do not invert or filter them — that would recolour the
+ * plots, and the colours carry meaning.
+ */
+@media (prefers-color-scheme: dark) {
+  .post-content img {
+    background: #ffffff;
+    border-radius: var(--radius);
+    padding: 0.5rem;
+  }
 }
 
 /* Collapsed cells (fastpages `#collapse-hide` / `#collapse-output`) -------- */
@@ -395,7 +520,7 @@ a:focus-visible {
 
 .btn-primary {
   background: var(--link);
-  color: #fff;
+  color: var(--on-link);
 }
 
 .btn-primary:hover {


### PR DESCRIPTION
Phase 5 of the Astro migration, plus one Phase 2 cleanup you asked for.

`astro check` clean, all 16 parity tests green, feed/sitemap/search still build.

## The five TL;DR drafts — please read these first

These are the only *authored* content in the whole migration and they go out
under your name, so they want your eye more than the CSS does. Each is anchored
on the post's existing `description` and says what the post concluded. Numbers
are quoted from the notebook outputs.

**What is the effect of flipped classroom groups on grades?**
- Three sections of a flipped-classroom course, with students randomly assigned to breakout groups of about four. The question: did the group you landed in move your final grade?
- No — not detectably. Across four tests (permutation, semiparametric bootstrap, ANOVA F, Welch F) the smallest p-value was 0.053, in Section 2. Correcting for the three sections needs a rejection threshold around 0.15 before that counts, under Benjamini-Hochberg as well as Bonferroni.
- That is a null result, not evidence of no effect. Simulation puts the power of all four tests low at these group sizes: only an effect as large as the observed spread in sample group means is reliably detected.
- The semiparametric bootstrap is by far the weakest of the four at groups of four, and catches up with the others at groups of ten — the group size is the problem, not the method.
- The permutation test and the uncorrected F-test tracked each other to within 0.01 on all three sections, which suggests ANOVA holds up here despite the grades being clearly left-skewed rather than normal.

**The Latent Space of Podcasts**
- Nearly a million Apple Podcasts reviews from Kaggle, curated down to 933 podcasts and 10,607 users with 40,585 positive ratings — a sparse matrix, about 0.4% filled.
- Almost every rating is five stars, so the star values carry little signal. The ratings are treated as *implicit* feedback instead — a preference plus a confidence, with a missing rating read as weak evidence against — and fitted with Alternating Least Squares.
- That works: precision@1 of 9.3% against 2.9% for a recommend-the-most-popular baseline, and the per-podcast similar-item lists look sensible by eye.
- Running PCA over the 50-dimensional podcast factors gives two readable axes: the first runs from self-improvement to pure entertainment (true crime at the far end), the second separates podcasts aimed at children from those aimed at adults. Both fall out of ratings alone — the model never sees a title, a description or a category.
- The main caveat is the dataset: its curator confirmed that many of the most popular podcasts were left out deliberately, and without knowing the selection rule there is no correcting for the resulting sampling bias.

**The Titanic has a Leak**
- Passengers travelling together on the Titanic mostly lived or died together, and Kaggle's train-test split cuts straight through those groups. A model can therefore predict a passenger from the fate of their family in the training set — information nobody would have had before the ship sank.
- The fix is a leak-proof cross-validation: reconstruct the travelling groups from names, tickets and cabins, then split so that a group is entirely in train or entirely in test, never both.
- With the leak closed, a tuned XGBoost still beats the baselines — 0.822 mean accuracy against 0.801 for the enhanced gender model and 0.780 for predicting on sex alone. There is real signal in the data beyond the leakage.
- Given the chance, the model does seem to take it. With the truncated-ticket feature its leaky-CV accuracy sits above its leak-proof accuracy, and dropping that feature reverses the gap. Its whole advantage over the baselines comes from passengers travelling in groups: on the 41% travelling alone it only matches the baselines, or does worse.
- The post's own caveat, kept here: most of these gaps are one to two standard errors wide, so they are suggestive rather than settled. Paired hypothesis tests across the folds are named as the next step.

**Comparing the Sentiment of Reviews and Ratings, with VADER and BERT**
- Podcast reviews carry preference signal the star rating misses — a one-star review is sometimes a fan complaining about the audio. This post asks how much of that two off-the-shelf sentiment methods recover: VADER, and a distilBERT already fine-tuned on SST2.
- Scored against the ratings on a 100,000-review sample balanced at 20,000 per star, VADER manages 0.568 three-class accuracy, with recall of just 0.20 on the neutral (three-star) class. Collapsed to binary at the single best possible threshold it reaches 0.718 — and that threshold is fitted on the same data, so treat it as an optimistic baseline.
- The two methods disagree most sharply on three-star reviews: VADER scores them overwhelmingly positive, distilBERT calls them mostly negative. Reading the reviews, the post sides with distilBERT and puts VADER's behaviour down to a positivity bias.
- Where they conflict, distilBERT is usually the one that is right. It reads "used to be a great comedy podcast, until…" as negative, where VADER's bag of words counts *great*, *wisdom* and *talent* and scores it 0.95.
- It is not better at everything: distilBERT's probabilities pile up at 0 and 1, making it a confident binary classifier rather than a usable continuous measure of sentiment. VADER is the better instrument for that.

**Training distilBERT to Predict Podcast Ratings**
- Fine-tunes base distilBERT on 80,000 podcast reviews to predict the star rating from the review's title and body, with Ray Tune searching the hyperparameters. Collapsing the five predicted ratings to two gives a sentiment classifier for free.
- On a 5,000-review test set balanced across ratings, that model reaches 0.883 sentiment accuracy against 0.815 for the off-the-shelf distilBERT fine-tuned on SST2 — a real gain for roughly two epochs of training.
- Predicting the star rating itself, all five classes, is much harder: 0.589. The stars are noisy labels, and neighbouring ones especially so.
- Fine-tuning buys domain knowledge, not just fit. The model picks up conventions specific to podcast reviews — reviews of horror podcasts use language that reads as negative in general English while plainly approving of the show.
- Confidence is not accuracy. Trained on to 40,000 steps (4 epochs) the output probabilities pile up at 0 and 1 while the evaluation loss climbs and accuracy falls below the 17,000-step checkpoint. The post reads that sharpening as a symptom of overfitting rather than a sign of learning.

### Bullets I am least sure about

Everything numeric is quoted from a cell output and re-checked, so my doubts are
about characterisation, not arithmetic:

1. **Grades, bullet 3** — "only an effect as large as the observed spread in sample group means is reliably detected" compresses the post's "the only scenario in which the power is above 0.8 is when the true group means vary as much as the sample group means". I believe that is faithful; it is the bullet where a reader is most likely to hear a stronger claim than you made.
2. **Titanic, bullet 4** — "the model does seem to take it" states as a mild finding what the post treats as a conjecture, and the post is emphatic about the caveat. Bullet 5 carries the hedge, but if you want the hedge inside bullet 4 as well, say so.
3. **BERT, bullet 4** — the horror-podcast example. Your summary says the fine-tuned model learned cases specific to podcast reviews; I did not find a side-by-side showing the SST2 model failing that exact case, so the bullet claims only that the fine-tuned model picks up the convention.
4. **VADER, bullet 3** — "the post sides with distilBERT" is my reading of "from reading some of the 3 star reviews it does appear that the distilBERT model is right".

## The rest

- **Home page** — short intro over the post list, replacing the bare `# Posts`. The intro describes you; check the wording. Post entries now show reading time.
- **Archive note** — one line on each of the five, wording taken from the plan.
- **Reading time** — counted over prose only, with fenced code stripped, or the notebook dumps would treble every estimate.
- **Tags** — five per post. They render as plain labels, not links: there are no tag index pages, and adding them would mint URLs that are not in the frozen list. Easy to make them links later if you want the pages.
- **Dark mode** — `prefers-color-scheme` only, no toggle. Checked both schemes in a preview build.
- **Alt text** — all 31 plots. nbconvert had written `[png]`, which names the file format rather than the figure.

## Colab leftovers — fixed, at your request

Google Colab wraps every dataframe in a "convert to interactive table" widget: a
container div, a button, an unscoped `<style>` and a `<script>` calling
`google.colab`. None of it works outside Colab, and it survived the Phase 2
conversion into the two 2022-10-21 posts — the styles applied site-wide, and the
scripts were indented enough that Markdown rendered them as a visible block of
JavaScript mid-post.

`COLAB_TABLE` in `scripts/convert-notebooks.py` now keeps the table and drops
the widget, and the two committed posts were rewritten with that same regex, so
re-running the script reproduces exactly what is committed here. All 14 tables
survive with every cell intact — checked by comparing `<table>` and `<td>` counts
before and after. That accounts for the ~930 deleted lines in the diff.

This is Phase 2's work rather than Phase 5's, so it is a separate commit
(`6b4b5e1`) and easy to drop on its own if you would rather it landed elsewhere.

## One more thing worth a human eye

**Code blocks changed in light mode too.** Shiki now emits `github-light` and
`github-dark` and the stylesheet picks one, so code follows the colour scheme.
Previously it was pinned to `github-dark`, i.e. dark code blocks on a white
page. That was Astro's default rather than a decision, and leaving it would have
made code the one element ignoring dark mode — but it does change how every post
looks in light mode. One line in `astro.config.mjs` to revert.

Also noted for Phase 6: `docs/decisions.md` is 79 lines against its 40-line
budget, and I added 13 of those.