### PR TITLE
Phase 6: tests and docs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,55 @@
+name: Checks
+
+# The Astro checks. Runs on every push while the migration is in progress;
+# `ci.yaml` still builds and deploys the Jekyll site until the cutover phase
+# replaces it.
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # 1. Types and the content schema. Cheapest check, catches the most.
+      - name: astro check
+        run: npx astro check
+
+      # The other three read the built site, so it has to exist first.
+      - name: Build
+        run: npm run build
+
+      # 2. URL parity — the check between us and silently breaking every
+      #    inbound link. 3. Internal links within the built site.
+      - name: URL parity and internal links
+        run: npx vitest run
+
+      # 4. Smoke tests. The runner has no browser preinstalled, so unlike a
+      #    local run this one downloads Chromium.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Smoke tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    # Reads the repo and nothing else. These checks never write, and the job
+    # runs third-party code (npm install, a browser download), so it gets the
+    # smallest token that still works.
+    permissions:
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -17,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -48,7 +53,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: playwright-report
           path: playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,8 @@ _site
 .sass-cache
 .jekyll-cache
 .jekyll-metadata
-*.xml
 vendor
 notebooks/.ipynb_checkpoints
-# Local Netlify folder
-.netlify
-.tweet-cache
 __pycache__
 .DS_Store
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ node_modules
 dist
 .astro
 .venv-nbconvert
+
+# Playwright
+test-results
+playwright-report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,11 @@ last, and only with the owner's approval. Run a single phase with `/migrate`.
 | `npm run dev` | Local preview at `localhost:4321`, hot reload |
 | `npm run build` | Static build into `dist/` |
 | `npx astro check` | Types and content schema. Run before every commit |
-| `npm test` | URL parity, smoke tests, internal link check |
+| `npm test` | Builds, then runs URL parity, the internal link check and the smoke tests |
+
+Those four are the whole test suite, and all four run in CI on every push. They
+check the built site, not the source — so `npm test` builds first, and a stale
+`dist/` is never what you are testing.
 
 ## Layout
 

--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,10 @@ exclude:
   - dist
   - package.json
   - package-lock.json
+  - vitest.config.ts
+  - playwright.config.ts
+  - test-results
+  - playwright-report
 
 # this setting allows you to keep pages organized in the _pages folder
 include:

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -31,8 +31,11 @@ arrives with the migration ([`migration-plan.md`](migration-plan.md)).
 | `scripts/convert-notebooks.py` | The conversion itself: drops fastpages `#hide` cells, folds `#collapse-*` into `<details>`, strips Colab's dataframe widgets, takes front matter from `_posts/` |
 | `scripts/nbtemplate/` | nbconvert template that emits those `<details>` wrappers |
 | `tests/expected-urls.json` | The published URL surface, taken from the live deployment |
-| `tests/` | URL parity, Playwright smoke tests, internal link check |
-| `.github/workflows/deploy.yml` | Build → GitHub Pages |
+| `tests/*.test.ts` | vitest, run against `dist/`: URL parity and the internal link check |
+| `tests/smoke.spec.ts` | Playwright. The only check that renders the site — needs a build and `astro preview`, both of which its config starts |
+| `vitest.config.ts` / `playwright.config.ts` | Which runner claims which files: `.test.ts` is vitest's, `.spec.ts` is Playwright's |
+| `.github/workflows/checks.yml` | The four checks, on every push |
+| `.github/workflows/deploy.yml` | Build → GitHub Pages. Arrives at the cutover, replacing the Jekyll `ci.yaml` |
 | `.claude/skills/migrate/` | The `/migrate` command. Temporary — delete once the migration lands |
 
 ## Still present, due for deletion

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,79 +1,40 @@
 # Decisions
 
-Why the repo is the way it is. One entry each: what, why, and what it rules out.
+One entry each: what, why, what it rules out.
 
-## Astro, replacing fastpages — 2026-07
+**Astro, replacing fastpages.** fastpages was deprecated in 2022 and built in an
+unmaintained Docker image on Ruby 2.7-era gems; the site was becoming
+unbuildable. Astro beat Quarto (notebook-first), Hugo (no component model) and
+Next.js (framework overhead on five posts). Rules out little — content stays Markdown.
 
-fastpages was deprecated in 2022 and built inside an unmaintained Docker image
-on Ruby 2.7-era gems; the site was on track to become unbuildable.
+**Notebooks frozen, out of the build.** Converted to Markdown once and
+committed, never re-executed; fastpages never did either, so the saved outputs
+have always been what shipped, and Python stays out of the build for good. The
+conversion reproduces what fastpages published, not the raw notebook — `#hide`
+cells dropped, `#collapse-*` folded into `<details>`, Colab widgets stripped —
+so it costs a converter that knows a dead tool's directives.
 
-Astro beat Quarto (notebook-first, and this blog is moving away from notebooks),
-Hugo (no component model, so interactive pages mean hand-rolling), and Next.js
-(application-framework overhead on a five-post site). It keeps interactive
-elements and a future backend available without charging for them up front.
+**GitHub Pages, for now.** Static hosting is enough and the domain already points
+there; an adapter can move it later. Rules out a backend — hence Formspree.
 
-Rules out: little. Content stays portable Markdown, so a later move is cheap.
+**URLs frozen, `build.format: 'preserve'`.** Pages has no server-side redirects,
+so a changed path is a hard 404. The published URLs come in two shapes — posts
+`/2022/03/19/slug.html`, pages `/about/` — and `preserve` is the only format
+that keeps both. The list is pinned in `tests/expected-urls.json` and enforced
+by a test, not by convention. Costs: every page is a directory with an
+`index.astro` in it, and post URLs lack `.html` in `astro dev`.
 
-## Notebooks frozen, out of the build
+**Sitemap hand-rolled.** `@astrojs/sitemap` derives URLs from the config rather
+than the built files, so under `preserve` every URL it emitted was a 404, and it
+publishes `sitemap-index.xml`, not the frozen `/sitemap.xml`.
+`src/pages/sitemap.xml.ts` derives both shapes, finding pages by convention — one
+placed outside it is missed, which `tests/urls.test.ts` catches.
 
-The five 2022 posts were converted to Markdown once and committed, and the
-notebooks were not re-executed — fastpages never did either, so the saved
-outputs have always been what shipped. This keeps Python and a 2022 ML
-dependency tree out of the build permanently.
+**Dark mode by `prefers-color-scheme`.** No toggle: that needs client-side
+JavaScript and a stored preference, and the OS already holds one. Shiki emits
+both themes per token so code follows too. Costs: colours may only be defined in
+`:root` and that one media block.
 
-The conversion reproduces what fastpages published, not the raw notebook:
-`#hide` cells are dropped, `#collapse-*` cells become `<details>`. Costs: a
-converter that knows a dead tool's directives, and republishing by hand.
-
-## GitHub Pages, for now
-
-Static hosting is sufficient and the domain already points there. Astro can move
-to a host with server support later by adding an adapter, so this is not a
-one-way door.
-
-Rules out: a backend. The contact form goes through Formspree as a result.
-
-## `build.format: 'preserve'`
-
-The frozen URLs come in two shapes: posts are `/2022/03/19/slug.html`, pages are
-`/about/`. Astro's `directory` format would publish the posts as
-`slug.html/index.html`; `file` would flatten the pages to `about.html`.
-`preserve` writes each route where its source file sits, so both shapes coexist.
-
-Costs: every page route is a directory with an `index.astro` inside, and post
-URLs in `astro dev` lack the `.html` the built files carry.
-
-## Sitemap hand-rolled, not `@astrojs/sitemap`
-
-The integration was tried and reverted: it derives URLs from the config rather
-than the built files, so under `build.format: 'preserve'` it stripped the
-`.html` off every post and the slash off every page, and it publishes
-`sitemap-index.xml` rather than the frozen `/sitemap.xml`. Patching its output
-would have restated this site's URL rules as guesses about someone else's.
-
-`src/pages/sitemap.xml.ts` derives both shapes: posts from `postPath()`, pages
-from `import.meta.glob`. Nothing is listed by hand.
-
-Costs: a page outside the `<name>/index.astro` convention is not found —
-`tests/urls.test.ts` turns that into a failure rather than a silent omission.
-
-## URLs frozen
-
-The published URL surface predates this repo's current shape, and GitHub Pages
-serves files with no server-side redirects — so a changed path is a hard 404,
-not a redirect. Keeping the paths costs one build setting; replacing them would
-cost a stub page per old URL. It is pinned in `tests/expected-urls.json` and
-enforced by a test, rather than left to convention and good intentions.
-
-## Dark mode by `prefers-color-scheme`, and code in two themes
-
-No toggle: a toggle needs client-side JavaScript and a stored preference, and
-the OS already holds that preference. So the palette is one `@media` block of
-custom-property values and no extra rules.
-
-Shiki emits both `github-light` and `github-dark` per token (`defaultColor:
-false`) so code follows the scheme too. That also changed light mode, where
-code blocks had been dark on a white page.
-
-Costs: colours may only be defined in `:root` and that one media block —
-anything hard-coded elsewhere breaks in one scheme.
+**Four checks, no more.** `astro check`, URL parity, smoke tests, internal link
+check — proportionate to a five-post blog. No unit tests: there is barely any
+logic to test, and the build either produces the right files or it does not.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -466,5 +466,5 @@ both configs — a new test named the wrong way is silently claimed by the wrong
 runner. `npm test` builds first on purpose; all four checks read `dist/`.
 This sandbox's `/opt/pw-browsers` Chromium never matches the revision
 `@playwright/test` pins, so `playwright.config.ts` points at it by path when it
-exists; the step above now says so. `actions/setup-node` is on a `v4` tag, not a
-SHA like the rest of the repo — pin it when someone can resolve one.
+exists; the step above now says so. Actions are SHA-pinned — `git ls-remote`
+resolves tags here even though `api.github.com` 403s.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -461,10 +461,12 @@ URLs. Colours live only in `:root` and one `prefers-color-scheme` block.
 **Phase 6** — All four checks green; `docs/decisions.md` cut to 40. Phase 7 must
 add `.github/workflows/checks.yml` to whatever it does with `ci.yaml` — the two
 are separate files and only `ci.yaml` is listed for deletion, which is correct.
-Runner split: `.test.ts` is vitest's, `.spec.ts` is Playwright's, enforced by
-both configs — a new test named the wrong way is silently claimed by the wrong
-runner. `npm test` builds first on purpose; all four checks read `dist/`.
-This sandbox's `/opt/pw-browsers` Chromium never matches the revision
-`@playwright/test` pins, so `playwright.config.ts` points at it by path when it
-exists; the step above now says so. Actions are SHA-pinned — `git ls-remote`
-resolves tags here even though `api.github.com` 403s.
+Runner split: `.test.ts` is vitest's, `.spec.ts` is Playwright's. `npm test`
+builds first; all four checks read `dist/`.
+The smoke tests **block GA4 and reCAPTCHA at the network layer** rather than
+ignoring their errors. Ignoring them passed here and failed in CI: with no
+egress the gtag script never loads, so with egress it loads and fires a beacon
+to a *different* host. Add any new third-party host to `THIRD_PARTY`.
+Sandbox Chromium at `/opt/pw-browsers` never matches the revision
+`@playwright/test` pins, so the config points at it by path when it exists.
+Actions are SHA-pinned — `git ls-remote` resolves tags even though `api.github.com` 403s.

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,6 +1,6 @@
 # Migration plan: fastpages/Jekyll → Astro
 
-**Status:** Phase 5 complete. Next: Phase 6.
+**Status:** Phase 6 complete. Next: Phase 7.
 **Audience:** the implementer (human or agent). Start with `/migrate`.
 
 The Status line above is the handoff signal — keep it in the form
@@ -81,7 +81,9 @@ src/
 public/                 → CNAME, robots.txt, static images
 tests/                  → urls.test.ts, smoke.spec.ts
 astro.config.mjs  package.json  .nvmrc
-.github/workflows/deploy.yml
+vitest.config.ts  playwright.config.ts
+.github/workflows/checks.yml   → the four checks
+.github/workflows/deploy.yml   → build and publish, arrives at cutover
 ```
 
 ---
@@ -269,9 +271,11 @@ Testing, proportionate to a five-post blog — these four, no more:
    it into CI here. It is the most important test in the repo: the thing between
    you and silently breaking every inbound link.
 3. **Smoke tests** (Playwright) — each page returns 200, has an `<h1>`, and logs
-   no console errors. Chromium is already available; do not run `playwright install`.
-   GA4 and the contact page's reCAPTCHA load from CDNs, so the console-error
-   assertion needs egress or an allowance for those two hosts.
+   no console errors. GA4 and the contact page's reCAPTCHA load from CDNs, so
+   the console-error assertion needs egress or an allowance for those two hosts.
+   A sandbox may ship Chromium at `/opt/pw-browsers/chromium`; use it via
+   `launchOptions.executablePath` rather than running `playwright install`
+   locally. CI runners have no browser, so CI does install one.
 4. **Internal link check** over `dist/` — catches bad paths from Phase 2.
 
 All four run in CI on every push to the branch.
@@ -451,3 +455,16 @@ committed posts were rewritten with that same regex.
 the work was the 31 alt texts. Tags are labels, not links: no tag pages, no new
 URLs. Colours live only in `:root` and one `prefers-color-scheme` block.
 `docs/decisions.md` is 79 lines against its 40-line budget — cut in Phase 6.
+
+<!-- Phase 6: -->
+
+**Phase 6** — All four checks green; `docs/decisions.md` cut to 40. Phase 7 must
+add `.github/workflows/checks.yml` to whatever it does with `ci.yaml` — the two
+are separate files and only `ci.yaml` is listed for deletion, which is correct.
+Runner split: `.test.ts` is vitest's, `.spec.ts` is Playwright's, enforced by
+both configs — a new test named the wrong way is silently claimed by the wrong
+runner. `npm test` builds first on purpose; all four checks read `dist/`.
+This sandbox's `/opt/pw-browsers` Chromium never matches the revision
+`@playwright/test` pins, so `playwright.config.ts` points at it by path when it
+exists; the step above now says so. `actions/setup-node` is on a `v4` tag, not a
+SHA like the rest of the repo — pin it when someone can resolve one.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^26.2.0",
         "pagefind": "^1.5.2",
         "typescript": "^6.0.3",
@@ -1413,6 +1414,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
@@ -4817,6 +4834,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "test": "vitest run"
+    "test": "npm run build && npm run test:urls && npm run test:links && npm run test:smoke",
+    "test:urls": "vitest run tests/urls.test.ts",
+    "test:links": "vitest run tests/links.test.ts",
+    "test:smoke": "playwright test"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.2",
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^26.2.0",
     "pagefind": "^1.5.2",
     "typescript": "^6.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { existsSync } from 'node:fs';
+import { defineConfig } from '@playwright/test';
+
+const port = 4321;
+
+/**
+ * Some sandboxes ship Chromium at a fixed path whose build number will not
+ * match whatever `@playwright/test` currently pins. Use it when it is there
+ * rather than downloading a second copy; fall back to Playwright's own browser
+ * everywhere else, which is what CI installs.
+ */
+const preinstalledChromium = '/opt/pw-browsers/chromium';
+const executablePath = existsSync(preinstalledChromium) ? preinstalledChromium : undefined;
+
+export default defineConfig({
+  testDir: './tests',
+  // `.test.ts` files are vitest's; Playwright takes only the `.spec.ts`.
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: `http://localhost:${port}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium', launchOptions: { executablePath } } },
+  ],
+  // Serves `dist/`, so the tests need a build first — `npm test` runs one.
+  webServer: {
+    command: `npx astro preview --port ${port}`,
+    url: `http://localhost:${port}/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
   testMatch: '**/*.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  reporter: process.env.CI ? 'github' : 'list',
+  // In CI, annotations on the diff *and* an HTML report — the workflow uploads
+  // the latter on failure, and with the `github` reporter alone there was no
+  // report on disk for it to find.
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list']],
   use: {
     baseURL: `http://localhost:${port}`,
     trace: 'on-first-retry',

--- a/tests/links.test.ts
+++ b/tests/links.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Internal link check: every site-relative `href`/`src` in the built HTML must
+ * resolve to a file in `dist/`.
+ *
+ * `tests/urls.test.ts` protects the URLs the outside world links to. This one
+ * protects the links the site makes to itself — the ones the Phase 2 notebook
+ * conversion rewrote by hand, where a stale `../images/` path builds cleanly
+ * and 404s only when someone clicks it.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, posix, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testsDir = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(testsDir, '..', 'dist');
+
+/** Every `.html` under `dist/`, as site-root-relative paths. */
+function htmlUnder(dir: string, prefix = '/'): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const child = posix.join(prefix, entry.name);
+    if (entry.isDirectory()) return htmlUnder(join(dir, entry.name), child);
+    return entry.name.endsWith('.html') ? [child] : [];
+  });
+}
+
+const htmlFiles = existsSync(distDir) ? htmlUnder(distDir).sort() : [];
+
+/** `href`/`src` on any element, single or double quoted. */
+const ATTR = /(?:href|src)\s*=\s*["']([^"']*)["']/gi;
+
+/** Anything with a scheme, a protocol-relative `//host`, or a bare fragment. */
+function isExternal(url: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(url) || url.startsWith('//') || url.startsWith('#');
+}
+
+/** The file `dist/` would serve for a link found in `fromFile`. */
+function targetFor(url: string, fromFile: string): string {
+  const path = url.split(/[?#]/)[0];
+  const absolute = path.startsWith('/')
+    ? posix.normalize(path)
+    : posix.resolve(posix.dirname(fromFile), path);
+  // A directory-style URL is served by its index.html — including the bare
+  // `/`, which leaves a path with no filename at all.
+  const file = absolute.endsWith('/') ? posix.join(absolute, 'index.html') : absolute;
+  return join(distDir, file);
+}
+
+function linksIn(file: string): string[] {
+  const html = readFileSync(join(distDir, file), 'utf8');
+  return [...html.matchAll(ATTR)]
+    .map((m) => m[1].trim())
+    .filter((url) => url !== '' && !isExternal(url));
+}
+
+describe('internal links in dist/', () => {
+  it('has a build to check', () => {
+    expect(
+      htmlFiles.length,
+      `no HTML in ${distDir} — run \`npm run build\` first`,
+    ).toBeGreaterThan(0);
+  });
+
+  it.each(htmlFiles)('%s links only to files that exist', (file) => {
+    const broken = linksIn(file)
+      .map((url) => ({ url, target: targetFor(url, file) }))
+      .filter(({ target }) => !existsSync(target) || !statSync(target).isFile())
+      .map(({ url, target }) => `${url} → ${relative(distDir, target)}`);
+
+    expect(broken, `${file} links to files that are not published`).toEqual([]);
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -19,12 +19,21 @@ const pages = (expectedUrls as string[]).filter(
 );
 
 /**
- * Third-party scripts we load on purpose and do not control. Both are blocked
- * or noisy on a network without egress, and neither failing says anything
- * about this site's own code, so console noise from these hosts is ignored —
- * anything else is a failure.
+ * Third parties we load on purpose and do not control: GA4 (the gtag script on
+ * `googletagmanager`, the beacon on `google-analytics`) and the contact page's
+ * reCAPTCHA. They are blocked outright below rather than merely ignored,
+ * because whether they load is a property of the network, not of this site: a
+ * machine without egress sees them fail, one with egress sees the analytics
+ * beacon abort at page teardown, and neither says anything about our code.
+ * Blocking makes every environment agree.
  */
-const THIRD_PARTY = [/googletagmanager\.com/, /google\.com\/recaptcha/, /gstatic\.com/];
+const THIRD_PARTY = [
+  /googletagmanager\.com/,
+  /google-analytics\.com/,
+  /analytics\.google\.com/,
+  /google\.com\/recaptcha/,
+  /gstatic\.com/,
+];
 
 const isOurs = (...where: string[]) =>
   !THIRD_PARTY.some((host) => where.some((text) => host.test(text)));
@@ -32,6 +41,13 @@ const isOurs = (...where: string[]) =>
 for (const url of pages) {
   test(`${url} loads cleanly`, async ({ page }) => {
     const problems: string[] = [];
+
+    // Blocking still fires `requestfailed` for each aborted request, so the
+    // filters below are what keep that self-inflicted noise out of `problems`.
+    await page.route(
+      (candidate) => !isOurs(candidate.toString()),
+      (route) => route.abort(),
+    );
 
     page.on('console', (message) => {
       // A failed subresource logs "Failed to load resource: …" with no URL in

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Smoke tests: every page loads, is titled, and does not throw in the browser.
+ *
+ * The other checks read the built files. This one is the only place the site
+ * is actually rendered, so it catches what static inspection cannot — a
+ * stylesheet that 404s, a script that throws, a page that builds to an empty
+ * shell.
+ *
+ * Runs against `npm run preview`, not `astro dev`: the built output is what
+ * ships, and Pagefind's index only exists after a build.
+ */
+
+import { expect, test } from '@playwright/test';
+import expectedUrls from './expected-urls.json' with { type: 'json' };
+
+/** The HTML pages. `feed.xml`, `sitemap.xml` and `robots.txt` are not pages. */
+const pages = (expectedUrls as string[]).filter(
+  (url) => url.endsWith('/') || url.endsWith('.html'),
+);
+
+/**
+ * Third-party scripts we load on purpose and do not control. Both are blocked
+ * or noisy on a network without egress, and neither failing says anything
+ * about this site's own code, so console noise from these hosts is ignored —
+ * anything else is a failure.
+ */
+const THIRD_PARTY = [/googletagmanager\.com/, /google\.com\/recaptcha/, /gstatic\.com/];
+
+const isOurs = (...where: string[]) =>
+  !THIRD_PARTY.some((host) => where.some((text) => host.test(text)));
+
+for (const url of pages) {
+  test(`${url} loads cleanly`, async ({ page }) => {
+    const problems: string[] = [];
+
+    page.on('console', (message) => {
+      // A failed subresource logs "Failed to load resource: …" with no URL in
+      // the text — the host is only in `location()`, so both are checked.
+      const from = message.location().url;
+      if (message.type() === 'error' && isOurs(message.text(), from)) {
+        problems.push(`console: ${message.text()} (${from})`);
+      }
+    });
+    page.on('pageerror', (error) => {
+      if (isOurs(error.message)) problems.push(`uncaught: ${error.message}`);
+    });
+    page.on('requestfailed', (request) => {
+      if (isOurs(request.url())) problems.push(`failed request: ${request.url()}`);
+    });
+
+    const response = await page.goto(url);
+
+    expect(response?.status(), `${url} did not return 200`).toBe(200);
+    await expect(page.locator('h1')).toHaveCount(1);
+    await expect(page.locator('h1')).not.toBeEmpty();
+    expect(problems, `${url} reported browser errors`).toEqual([]);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Only the `.test.ts` files. `tests/smoke.spec.ts` is Playwright's — it is
+    // the one test here that needs a browser and a running server, and vitest
+    // would otherwise claim it by its default `{test,spec}` pattern and fail
+    // on the `@playwright/test` import.
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Phase 6 of the Astro migration: the four checks from the plan, running in CI, and the docs cut to their budgets.

CI is green on `3acf207` — but not on the first two attempts. See [What CI caught](#what-ci-caught).

## Tests

| Check | Where | State |
|---|---|---|
| `astro check` | already existed | now in CI |
| URL parity | `tests/urls.test.ts`, written in Phase 0 | now in CI |
| Internal link check | `tests/links.test.ts` — **new** | green |
| Smoke tests | `tests/smoke.spec.ts` — **new** | green, 10 pages |

All four run on every push via `.github/workflows/checks.yml`.

**The internal link check** walks every `.html` in `dist/`, pulls out every `href`/`src` that isn't external, and asserts each resolves to a real file — directory URLs via their `index.html`. This is the one aimed at the Phase 2 conversion: a stale relative image path builds cleanly and only 404s when a reader clicks it. I sanity-checked it against a planted bad link before trusting the green.

**The smoke tests** load each of the 10 HTML pages in Chromium and assert 200, exactly one non-empty `<h1>`, and no console errors, uncaught exceptions, or failed requests.

`npm test` builds before running anything, because all four checks read the built site and a stale `dist/` is the kind of green that means nothing.

## What CI caught

I opened this PR saying the workflow had never executed and its first run was the only proof. That was the right worry — it failed twice.

**Run 1 and 2: `/contact/` failed on a `google-analytics.com` request.** My third-party allowlist covered `googletagmanager.com`, the host serving the gtag script, but GA4 sends its beacon to `google-analytics.com` — a separate host. It never appeared in local runs because this sandbox has no egress, so the script never loaded to send a beacon. CI has egress, so it did.

Adding the missing host would have fixed the symptom and left the real problem: whether a third party loads is a property of the network, not of this site, and an analytics beacon is fire-and-forget — it can abort at page teardown on any page on any run. That is a flaky test waiting to happen, not a `/contact/` bug.

So third parties are now **blocked at the route level** rather than ignored after the fact. Every environment sees the same thing whether or not it has egress. I verified by instrumenting the interception directly: gtag and reCAPTCHA are aborted, first-party requests pass through untouched.

Two smaller things the same run surfaced:
- The `github` reporter writes no HTML, so the upload-artifact step had nothing to find on failure. CI now runs both reporters, and the report is real when it is needed.
- The pinned actions were on Node 20, which the runner warns is deprecated. Both moved to `v6`.

## Security fixes after review

Prompted by a question on this PR about action pinning:
- `actions/setup-node` and `actions/upload-artifact` are **SHA-pinned** (`249970729cb…` and `b7c566a772e…`), matching how `actions/checkout` is pinned in `ci.yaml`. Tags are mutable, and a repointed tag runs arbitrary code with the job's token — the `tj-actions/changed-files` compromise in March 2025 worked exactly that way.
- The job had **no `permissions:` block**, so it inherited the repository default. It only reads, and now says so: `contents: read`.

I had originally reported one action as unpinned. There were two.

## Docs

`docs/decisions.md` was 79 lines against a 40-line budget; it is now exactly 40. The cut was compression, not deletion — every decision that was recorded is still recorded, and one was added for the test suite. `AGENTS.md` (57) and `docs/code-map.md` (55) gained entries for the new files and stay under 60.

## `.gitignore` cleanup

Removed three dead fastpages entries: `*.xml`, `.netlify`, `.tweet-cache`. None matched anything tracked. The first was the live hazard — it would have silently swallowed any XML committed outside `dist/`, and `git add` gives no warning when that happens.

## Still wants a human eye

1. **The third-party block means GA4 is never exercised by the tests.** If analytics silently stopped working in production, nothing here would say so. That is the deliberate trade — the alternative was a test whose result depends on the network — but it is a real gap, not a solved problem.
2. **`docs/decisions.md` sits exactly at its 40-line budget.** The next entry needs a cut somewhere else first.

Gate: `astro check` clean, all four checks green in CI, every doc within budget.