### PR TITLE
Drop the last references to the deleted migration plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,5 +57,4 @@ Why they're that way: [`docs/decisions.md`](docs/decisions.md).
 
 ## Ask first
 
-Before adding a dependency, a client-side island, a new top-level directory, or
-anything outside the current phase of the migration plan.
+Before adding a dependency, a client-side island, or a new top-level directory.

--- a/scripts/convert-notebooks.py
+++ b/scripts/convert-notebooks.py
@@ -243,7 +243,7 @@ def convert(path: Path, exporter: MarkdownExporter) -> tuple[str, int]:
     meta["date"] = date
     meta["notebook"] = f"notebooks/{path.name}"
     meta["archived"] = True
-    # `tldr` and `tags` are authored in Phase 5, not derived from the notebook.
+    # `tldr` and `tags` are hand-authored, not derived from the notebook.
 
     index = post_dir / "index.md"
     index.write_text(front_matter(meta) + body, encoding="utf8")

--- a/tests/links.test.ts
+++ b/tests/links.test.ts
@@ -3,7 +3,7 @@
  * resolve to a file in `dist/`.
  *
  * `tests/urls.test.ts` protects the URLs the outside world links to. This one
- * protects the links the site makes to itself — the ones the Phase 2 notebook
+ * protects the links the site makes to itself — the ones the notebook
  * conversion rewrote by hand, where a stale `../images/` path builds cleanly
  * and 404s only when someone clicks it.
  */


### PR DESCRIPTION
Phase 7 already deleted `.claude/skills/migrate/` and `docs/migration-plan.md`, exactly as the plan instructed — the skill was built to remove itself when the migration landed. This cleans up the three comments that still point at them.

## What changed

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | "Before adding a dependency, a client-side island, a new top-level directory, or anything outside **the current phase of the migration plan**." | The clause is gone; the other three things to ask about stay. |
| `scripts/convert-notebooks.py` | "`tldr` and `tags` are authored in **Phase 5**" | "`tldr` and `tags` are hand-authored" |
| `tests/links.test.ts` | "the ones the **Phase 2** notebook conversion rewrote by hand" | "the ones the notebook conversion rewrote by hand" |

The AGENTS.md line is the one that mattered — it was a live instruction to consult a file that no longer exists. There is no current phase, so the clause goes. The two code comments keep their point without dating it to a phase number.

Comments and one doc sentence only. No behaviour change.

## Verification

`npx astro check` clean (20 files, 0 errors) and all four checks green via `ASTRO_PREVIEW_BACKGROUND=1 npm test` — URL parity, internal links (11 tests), and 10 Playwright smoke tests.

## What wants your eye

Nothing blocking, but worth knowing: **Phase 8 was never done.** It was the plan's optional post-merge item — connect the repo to Cloudflare Pages for per-branch preview URLs, production staying on GitHub Pages. It is the only unexecuted phase, and it is dashboard configuration rather than repo work, so it is deliberately not in this PR. With the plan deleted, that text now survives only in git history at `8aa60d5^:docs/migration-plan.md`.

One detail if you do pick it up: `astro.config.mjs` hardcodes `site: 'https://david-recio.com'`, so preview builds would emit canonical tags, `sitemap.xml`, and `feed.xml` pointing at production. Cosmetic for previews, and fixable in one line if it bothers you.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQmrYZUWHtpk2ww2MXrFNw)_